### PR TITLE
SOW-24: add GDS button component

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ This repository is a component library publishing two components as part of the 
 
 See the wiki [here](https://github.com/digital-land/local-plans-timetable/wiki).
 
+## Deployment
+
+The Storybook for this library is deployed to GitHub Pages: https://digital-land.github.io/local-plans-timetable/
+
+Assuming a successful lint/test run, all commits to `main` will trigger a new deployment.
+
 ## Available Scripts
 
 In the project directory, you can run:
@@ -52,9 +58,3 @@ export default {
 - Replace `plugin:@typescript-eslint/recommended` to `plugin:@typescript-eslint/recommended-type-checked` or `plugin:@typescript-eslint/strict-type-checked`
 - Optionally add `plugin:@typescript-eslint/stylistic-type-checked`
 - Install [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) and add `plugin:react/recommended` & `plugin:react/jsx-runtime` to the `extends` list
-
-## Deployment
-
-The Storybook for this library is deployed to GitHub Pages: https://digital-land.github.io/local-plans-timetable/
-
-Assuming a successful lint/test run, all commits to `main` will trigger a new deployment.

--- a/lib/gds-components/button/Button.tsx
+++ b/lib/gds-components/button/Button.tsx
@@ -1,3 +1,7 @@
+/**
+ * GDS component: https://design-system.service.gov.uk/components/button/
+ */
+
 interface ButtonProps {
   children?: React.ReactNode;
   type?: "submit" | "button" | "reset";

--- a/lib/gds-components/button/Button.tsx
+++ b/lib/gds-components/button/Button.tsx
@@ -1,0 +1,10 @@
+interface ButtonProps {
+  children?: React.ReactNode;
+  type?: "submit" | "button" | "reset";
+}
+
+export const Button = ({ children, type = "button" }: ButtonProps) => (
+  <button type={type} className="govuk-button">
+    {children}
+  </button>
+);

--- a/lib/timetable-form/Form.tsx
+++ b/lib/timetable-form/Form.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import "govuk-frontend/dist/govuk/govuk-frontend.min.css";
 
+import { Button } from "../gds-components/button/Button";
 import { TextInput } from "../gds-components/text-input/TextInput";
 import { DateInput } from "../gds-components/date-input/DateInput";
 import { Stages, FormData } from "../types/timetable";
@@ -62,7 +63,7 @@ export const Form = (props: React.HTMLAttributes<HTMLDivElement>) => {
         href={getTimetableDownload({ LPA: lpa, stages })}
         download="timetable.csv"
       >
-        <button> Export Timetable CSV</button>
+        <Button>Export Timetable CSV</Button>
       </a>
     </div>
   );


### PR DESCRIPTION
Add button component missed in original PR

![image](https://github.com/digital-land/local-plans-timetable/assets/29425751/5bb0271a-c9be-4705-8e1b-cc28ca8789e1)
