### PR TITLE
SOW-24: fix CDN typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Builds Storybook to the `storybook-static` folder.
 
 ### `npm run build:cdn`
 
-Builds the visualisation component for the CDN to the `dist` folder.
+Builds the visualisation component for the CDN to the `dist-cdn` folder.
 
 ## Expanding the ESLint configuration
 


### PR DESCRIPTION
Update the description for the `build:cdn` script