### PR TITLE
SOW-24: Implement event editing in timetable form

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -37,20 +37,20 @@ const stageKeyToNameMap = stages.reduce<Record<StageKey, string>>(
 
 export const getStageName = (key: StageKey) => stageKeyToNameMap[key];
 
-export const getDefaultDate = () => new Date().toISOString().split("T")[0];
+export const getFormattedDate = () => new Date().toISOString().split("T")[0];
 
 export const DEFAULT_DEVELOPMENT_PLAN: DevelopmentPlan = {
   reference: uuidv4(),
   name: "",
   description: "",
   developmentPlanType: "",
-  periodStartDate: getDefaultDate(),
+  periodStartDate: getFormattedDate(),
   developmentPlanGeography: "",
   documentationUrl: "",
-  adoptedDate: getDefaultDate(),
+  adoptedDate: getFormattedDate(),
   organisations: "",
-  entryDate: getDefaultDate(),
-  startDate: getDefaultDate(),
+  entryDate: getFormattedDate(),
+  startDate: getFormattedDate(),
   timetableEvents: stages.map(({ key }) => ({
     reference: uuidv4(),
     name: "",
@@ -59,8 +59,8 @@ export const DEFAULT_DEVELOPMENT_PLAN: DevelopmentPlan = {
     eventDate: "",
     notes: "",
     organisation: "",
-    entryDate: getDefaultDate(),
-    startDate: getDefaultDate(),
+    entryDate: getFormattedDate(),
+    startDate: getFormattedDate(),
     endDate: "",
   })),
 };

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,45 +1,66 @@
 import { v4 as uuidv4 } from "uuid";
 import { DevelopmentPlan } from "./types/timetable";
 
-export const stageNames = [
-  "Timetable published",
-  "Draft plan for public consultation published",
-  "Public consultation start",
-  "Public consultation end",
-  "Submit plan for examination",
-  "Examination hearing start",
-  "Planning inspectorate examination start",
-  "Planning inspectorate examination end",
-  "Planning inspectorate found sound",
-  "Examination hearing end",
-  "Inspector report published",
-  "Plan adopted",
+export const stages = [
+  { name: "Timetable published", key: "timetable-published" },
+  {
+    name: "Draft plan for public consultation published",
+    key: "draft-plan-for-public-consultation-published",
+  },
+  { name: "Public consultation start", key: "public-consultation-start" },
+  { name: "Public consultation end", key: "public-consultation-end" },
+  { name: "Submit plan for examination", key: "submit-plan-for-examination" },
+  { name: "Examination hearing start", key: "examination-hearing-start" },
+  {
+    name: "Planning inspectorate examination start",
+    key: "planning-inspectorate-examination-start",
+  },
+  {
+    name: "Planning inspectorate examination end",
+    key: "planning-inspectorate-examination-end",
+  },
+  {
+    name: "Planning inspectorate found sound",
+    key: "planning-inspectorate-found-sound",
+  },
+  { name: "Examination hearing end", key: "examination-hearing-end" },
+  { name: "Inspector report published", key: "inspector-report-published" },
+  { name: "Plan adopted", key: "plan-adopted" },
 ] as const;
 
-const defaultDate = new Date().toISOString().split("T")[0];
+export type StageKey = (typeof stages)[number]["key"];
+
+const stageKeyToNameMap = stages.reduce<Record<StageKey, string>>(
+  (acc, { key, name }) => ({ ...acc, [key]: name }),
+  {} as Record<StageKey, string>
+);
+
+export const getStageName = (key: StageKey) => stageKeyToNameMap[key];
+
+export const getDefaultDate = () => new Date().toISOString().split("T")[0];
 
 export const DEFAULT_DEVELOPMENT_PLAN: DevelopmentPlan = {
   reference: uuidv4(),
   name: "",
   description: "",
   developmentPlanType: "",
-  periodStartDate: defaultDate,
+  periodStartDate: getDefaultDate(),
   developmentPlanGeography: "",
   documentationUrl: "",
-  adoptedDate: defaultDate,
+  adoptedDate: getDefaultDate(),
   organisations: "",
-  entryDate: defaultDate,
-  startDate: defaultDate,
-  timetableEvents: stageNames.map((stage) => ({
+  entryDate: getDefaultDate(),
+  startDate: getDefaultDate(),
+  timetableEvents: stages.map(({ key }) => ({
     reference: uuidv4(),
     name: "",
     developmentPlan: "",
-    developmentPlanEvent: stage,
+    developmentPlanEvent: key,
     eventDate: "",
     notes: "",
     organisation: "",
-    entryDate: defaultDate,
-    startDate: defaultDate,
+    entryDate: getDefaultDate(),
+    startDate: getDefaultDate(),
     endDate: "",
   })),
 };

--- a/lib/timetable-form/Form.test.tsx
+++ b/lib/timetable-form/Form.test.tsx
@@ -2,8 +2,11 @@ import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import { stageNames } from "../constants";
-import { objectArrayToCSVString } from "../utils/timetable";
+import { stages } from "../constants";
+import {
+  objectArrayToCSVString,
+  resolveTimetableEventsCSV,
+} from "../utils/timetable";
 import { Form } from "./Form";
 import { PlanViewer } from "../timetable-visualisation/PlanViewer";
 
@@ -13,6 +16,7 @@ jest.mock("../timetable-visualisation/PlanViewer");
 describe("all activity users", () => {
   beforeEach(() => {
     (objectArrayToCSVString as jest.Mock).mockImplementation(() => {});
+    (resolveTimetableEventsCSV as jest.Mock).mockImplementation(() => {});
     (PlanViewer as jest.Mock).mockReturnValue(<></>);
   });
 
@@ -28,22 +32,23 @@ describe("all activity users", () => {
   test("Generates CSV file on render", () => {
     render(<Form />);
 
-    expect(objectArrayToCSVString).toHaveBeenCalledTimes(2);
+    expect(objectArrayToCSVString).toHaveBeenCalledTimes(1);
+    expect(resolveTimetableEventsCSV).toHaveBeenCalledTimes(1);
   });
 
   test("Updates the CSV when the state changes", async () => {
     render(<Form />);
 
     await userEvent.type(
-      screen.getByTestId(`${stageNames[1].replace(/ /gi, "-")}-date-month`),
+      screen.getByTestId(`${stages[1].key}-date-month`),
       "12"
     );
     await userEvent.type(
-      screen.getByTestId(`${stageNames[1].replace(/ /gi, "-")}-date-year`),
+      screen.getByTestId(`${stages[1].key}-date-year`),
       "2026"
     );
 
-    expect(objectArrayToCSVString).toHaveBeenCalledTimes(8);
+    expect(resolveTimetableEventsCSV).toHaveBeenCalledTimes(7);
   });
 
   test("renders a PlanPreview component", () => {

--- a/lib/types/timetable.ts
+++ b/lib/types/timetable.ts
@@ -1,6 +1,4 @@
-import { stageNames } from "../constants";
-
-export type StageName = (typeof stageNames)[number];
+import { StageKey } from "../constants";
 
 export type DevelopmentPlan = {
   reference: string;
@@ -23,7 +21,7 @@ export type DevelopmentPlanTimetable = {
   reference: string;
   name: string;
   developmentPlan: string;
-  developmentPlanEvent: StageName;
+  developmentPlanEvent: StageKey;
   eventDate: string;
   notes: string;
   organisation: string;

--- a/lib/utils/timetable.test.ts
+++ b/lib/utils/timetable.test.ts
@@ -1,0 +1,183 @@
+import { v4 as uuidv4 } from "uuid";
+
+import { DevelopmentPlanTimetable } from "../types/timetable";
+import { resolveTimetableEventsCSV } from "./timetable";
+import { getFormattedDate } from "../constants";
+
+jest.mock("uuid", () => ({
+  v4: jest.fn(),
+}));
+
+describe("resolveTimetableEventsCSV", () => {
+  test("returns the correct CSV if there are no loaded events", () => {
+    const timetableEvents: DevelopmentPlanTimetable[] = [
+      {
+        reference: "1",
+        name: "name",
+        developmentPlan: "development-plan",
+        developmentPlanEvent: "public-consultation-start",
+        eventDate: "2023-01-01",
+        notes: "",
+        organisation: "organisation",
+        entryDate: "2023-01-01",
+        startDate: "2023-01-01",
+        endDate: "",
+      },
+      {
+        reference: "2",
+        name: "name",
+        developmentPlan: "development-plan",
+        developmentPlanEvent: "examination-hearing-start",
+        eventDate: "2023-01-02",
+        notes: "",
+        organisation: "organisation",
+        entryDate: "2023-01-01",
+        startDate: "2023-01-01",
+        endDate: "",
+      },
+    ];
+
+    const result = resolveTimetableEventsCSV(timetableEvents, null);
+
+    expect(result).toBe(
+      "reference,name,developmentPlan,developmentPlanEvent,eventDate,notes,organisation,entryDate,startDate,endDate\n" +
+        "1,name,development-plan,public-consultation-start,2023-01-01,,organisation,2023-01-01,2023-01-01,\n" +
+        "2,name,development-plan,examination-hearing-start,2023-01-02,,organisation,2023-01-01,2023-01-01,"
+    );
+  });
+
+  test("returns the correct CSV string if there are no changes", () => {
+    const timetableEvents: DevelopmentPlanTimetable[] = [
+      {
+        reference: "1",
+        name: "name",
+        developmentPlan: "development-plan",
+        developmentPlanEvent: "public-consultation-start",
+        eventDate: "2023-01-01",
+        notes: "",
+        organisation: "organisation",
+        entryDate: "2023-01-01",
+        startDate: "2023-01-01",
+        endDate: "",
+      },
+      {
+        reference: "2",
+        name: "name",
+        developmentPlan: "development-plan",
+        developmentPlanEvent: "examination-hearing-start",
+        eventDate: "2023-01-02",
+        notes: "",
+        organisation: "organisation",
+        entryDate: "2023-01-01",
+        startDate: "2023-01-01",
+        endDate: "",
+      },
+    ];
+    const loadedTimetableEvents: DevelopmentPlanTimetable[] = [
+      {
+        reference: "1",
+        name: "name",
+        developmentPlan: "development-plan",
+        developmentPlanEvent: "public-consultation-start",
+        eventDate: "2023-01-01",
+        notes: "",
+        organisation: "organisation",
+        entryDate: "2023-01-01",
+        startDate: "2023-01-01",
+        endDate: "",
+      },
+      {
+        reference: "2",
+        name: "name",
+        developmentPlan: "development-plan",
+        developmentPlanEvent: "examination-hearing-start",
+        eventDate: "2023-01-02",
+        notes: "",
+        organisation: "organisation",
+        entryDate: "2023-01-01",
+        startDate: "2023-01-01",
+        endDate: "",
+      },
+    ];
+
+    const result = resolveTimetableEventsCSV(
+      timetableEvents,
+      loadedTimetableEvents
+    );
+
+    expect(result).toBe(
+      "reference,name,developmentPlan,developmentPlanEvent,eventDate,notes,organisation,entryDate,startDate,endDate\n" +
+        "1,name,development-plan,public-consultation-start,2023-01-01,,organisation,2023-01-01,2023-01-01,\n" +
+        "2,name,development-plan,examination-hearing-start,2023-01-02,,organisation,2023-01-01,2023-01-01,"
+    );
+  });
+
+  test("returns the correct CSV string if there are changes", () => {
+    (uuidv4 as unknown as jest.SpyInstance).mockImplementation(() => "3");
+    const timetableEvents: DevelopmentPlanTimetable[] = [
+      {
+        reference: "1",
+        name: "name",
+        developmentPlan: "development-plan",
+        developmentPlanEvent: "public-consultation-start",
+        eventDate: "2023-01-01",
+        notes: "",
+        organisation: "organisation",
+        entryDate: "2023-01-01",
+        startDate: "2023-01-01",
+        endDate: "",
+      },
+      {
+        reference: "2",
+        name: "name",
+        developmentPlan: "development-plan",
+        developmentPlanEvent: "examination-hearing-start",
+        eventDate: "2023-01-02",
+        notes: "",
+        organisation: "organisation",
+        entryDate: "2023-01-01",
+        startDate: "2023-01-01",
+        endDate: "",
+      },
+    ];
+    const loadedTimetableEvents: DevelopmentPlanTimetable[] = [
+      {
+        reference: "1",
+        name: "name",
+        developmentPlan: "development-plan",
+        developmentPlanEvent: "public-consultation-start",
+        eventDate: "2023-01-01",
+        notes: "",
+        organisation: "organisation",
+        entryDate: "2023-01-01",
+        startDate: "2023-01-01",
+        endDate: "",
+      },
+      {
+        reference: "2",
+        name: "name",
+        developmentPlan: "development-plan",
+        developmentPlanEvent: "examination-hearing-start",
+        eventDate: "2023-01-03",
+        notes: "",
+        organisation: "organisation",
+        entryDate: "2023-01-01",
+        startDate: "2023-01-01",
+        endDate: "",
+      },
+    ];
+
+    const result = resolveTimetableEventsCSV(
+      timetableEvents,
+      loadedTimetableEvents
+    );
+
+    const currentDate = getFormattedDate();
+    expect(result).toBe(
+      "reference,name,developmentPlan,developmentPlanEvent,eventDate,notes,organisation,entryDate,startDate,endDate\n" +
+        "1,name,development-plan,public-consultation-start,2023-01-01,,organisation,2023-01-01,2023-01-01,\n" +
+        `2,name,development-plan,examination-hearing-start,2023-01-03,,organisation,2023-01-01,2023-01-01,${currentDate}\n` +
+        `3,name,development-plan,examination-hearing-start,2023-01-02,,organisation,${currentDate},${currentDate},`
+    );
+  });
+});

--- a/lib/utils/timetable.ts
+++ b/lib/utils/timetable.ts
@@ -39,16 +39,18 @@ export const resolveTimetableEventsCSV = (
       (event) => event.reference === loadedEvent.reference
     );
     if (!formEvent) {
-      return;
+      // This shouldn't ever happen
+      throw Error("Form event not found");
     }
 
     if (formEvent.eventDate !== loadedEvent.eventDate) {
-      loadedEvent.endDate = getFormattedDate();
+      const currentDate = getFormattedDate();
+      loadedEvent.endDate = currentDate;
       eventsToDownload.push({
         ...formEvent,
         reference: uuidv4(),
-        entryDate: getFormattedDate(),
-        startDate: getFormattedDate(),
+        entryDate: currentDate,
+        startDate: currentDate,
       });
     }
   });

--- a/lib/utils/timetable.ts
+++ b/lib/utils/timetable.ts
@@ -1,8 +1,10 @@
-import { DEFAULT_DEVELOPMENT_PLAN } from "../constants";
+import { v4 as uuidv4 } from "uuid";
+
+import { DEFAULT_DEVELOPMENT_PLAN, getDefaultDate } from "../constants";
 import { DevelopmentPlan, DevelopmentPlanTimetable } from "../types/timetable";
 
-const objectArrayToCSVString = (
-  objArr: { [key: string]: unknown }[],
+export const objectArrayToCSVString = (
+  objArr: { [key: string]: unknown }[]
 ): string => {
   const headLine = Object.keys(objArr[0]).join(",");
 
@@ -11,19 +13,56 @@ const objectArrayToCSVString = (
       ...array,
       Object.values(timetableItem).join(","),
     ],
-    [headLine],
+    [headLine]
   );
 
   return CSVRows.join("\n");
 };
 
-const CSVStringToDevPlan = (csvString: string): DevelopmentPlan => {
+export const resolveTimetableEventsCSV = (
+  timetableEvents: DevelopmentPlanTimetable[],
+  loadedTimetableEvents: DevelopmentPlanTimetable[] | null
+): string => {
+  if (!loadedTimetableEvents) {
+    return objectArrayToCSVString(timetableEvents);
+  }
+
+  const eventsToDownload: DevelopmentPlanTimetable[] = JSON.parse(
+    JSON.stringify(loadedTimetableEvents)
+  );
+  eventsToDownload.forEach((loadedEvent) => {
+    if (loadedEvent.endDate) {
+      return;
+    }
+
+    const formEvent = timetableEvents.find(
+      (event) => event.reference === loadedEvent.reference
+    );
+    if (!formEvent) {
+      return;
+    }
+
+    if (formEvent.eventDate !== loadedEvent.eventDate) {
+      loadedEvent.endDate = getDefaultDate();
+      eventsToDownload.push({
+        ...formEvent,
+        reference: uuidv4(),
+        entryDate: getDefaultDate(),
+        startDate: getDefaultDate(),
+      });
+    }
+  });
+
+  return objectArrayToCSVString(eventsToDownload);
+};
+
+export const CSVStringToDevPlan = (csvString: string): DevelopmentPlan => {
   const [headLine, data] = csvString.split("\n");
 
   const keys = headLine.split(",");
   const values = data.split(",");
   const entries = keys.map((key, i) => [key, values[i]]);
-  
+
   const developmentPlan: DevelopmentPlan = Object.fromEntries(entries);
 
   return {
@@ -32,7 +71,7 @@ const CSVStringToDevPlan = (csvString: string): DevelopmentPlan => {
   };
 };
 
-const CSVStringToDevPlanTimetable = (
+export const CSVStringToDevPlanTimetable = (
   csvString: string
 ): DevelopmentPlanTimetable[] => {
   const [headLine, ...data] = csvString.split("\n");
@@ -49,20 +88,12 @@ const CSVStringToDevPlanTimetable = (
   return timetableEvents;
 };
 
-const loadCSV = async (filepath: string) =>
+export const loadCSV = async (filepath: string) =>
   await fetch(filepath).then((res) => res.text());
 
-const dateToDefaultLocalDateString = (date: Date) =>
+export const dateToDefaultLocalDateString = (date: Date) =>
   new Date(date).toLocaleDateString("en-uk", {
     day: "numeric",
     year: "numeric",
     month: "long",
   });
-
-export {
-  dateToDefaultLocalDateString,
-  objectArrayToCSVString,
-  loadCSV,
-  CSVStringToDevPlan,
-  CSVStringToDevPlanTimetable,
-};

--- a/lib/utils/timetable.ts
+++ b/lib/utils/timetable.ts
@@ -1,6 +1,6 @@
 import { v4 as uuidv4 } from "uuid";
 
-import { DEFAULT_DEVELOPMENT_PLAN, getDefaultDate } from "../constants";
+import { DEFAULT_DEVELOPMENT_PLAN, getFormattedDate } from "../constants";
 import { DevelopmentPlan, DevelopmentPlanTimetable } from "../types/timetable";
 
 export const objectArrayToCSVString = (
@@ -43,12 +43,12 @@ export const resolveTimetableEventsCSV = (
     }
 
     if (formEvent.eventDate !== loadedEvent.eventDate) {
-      loadedEvent.endDate = getDefaultDate();
+      loadedEvent.endDate = getFormattedDate();
       eventsToDownload.push({
         ...formEvent,
         reference: uuidv4(),
-        entryDate: getDefaultDate(),
-        startDate: getDefaultDate(),
+        entryDate: getFormattedDate(),
+        startDate: getFormattedDate(),
       });
     }
   });


### PR DESCRIPTION
Add editing to the timetable form, following the data structure approach of invalidating old rows.

This only addresses editing the events, I'll look into editing the plan data separately.