### PR TITLE
SOW-24: exclude favicon from CDN build

### DIFF
--- a/cdn-vite.config.ts
+++ b/cdn-vite.config.ts
@@ -5,6 +5,7 @@ import { resolve } from "path";
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  publicDir: false,
   build: {
     outDir: resolve(__dirname, "dist-cdn"),
     rollupOptions: {


### PR DESCRIPTION
Adding the favicon for the form wrapper app also included it in the CDN build, which isn't needed. Since we're already manually copying the fonts (and for now, I'm keeping that step since we're rewriting the URLs), we can just exclude the `public` directory from the build.