### PR TITLE
SOW-24: fix CSS modules in CDN build

### DIFF
--- a/cdn-vite.config.ts
+++ b/cdn-vite.config.ts
@@ -18,4 +18,7 @@ export default defineConfig({
       },
     },
   },
+  css: {
+    modules: { localsConvention: "camelCaseOnly" },
+  },
 });


### PR DESCRIPTION
Spotted this during some investigation around styling the CDN component. Currently we don't have any CSS modules for this component but without this option in the build, it wouldn't be possible to import kebab case classes as camel case.