### PR TITLE
SOW-24: cleanup test console errors and warnings

### DIFF
--- a/lib/timetable-form/Form.test.tsx
+++ b/lib/timetable-form/Form.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { stages } from "../constants";
@@ -16,32 +16,41 @@ jest.mock("../api/");
 jest.mock("../timetable-visualisation/PlanViewer");
 jest.mock('../validation');
 
+// This is mocked to avoid the warnings about componentWillMount and componentWillReceiveProps from the accessible-autocomplete component
+jest.mock("./autocomplete/Autocomplete");
+
 describe("all activity users", () => {
   beforeEach(() => {
     (resolveDevelopmentPlanCSV as jest.Mock).mockImplementation(() => {});
     (resolveTimetableEventsCSV as jest.Mock).mockImplementation(() => {});
     (fetchLPAs as jest.Mock).mockResolvedValue({ entities: [] });
-    (PlanViewer as jest.Mock).mockReturnValue(<></>);
+    (PlanViewer as jest.Mock).mockReturnValue(<>Plan viewer component</>);
   });
 
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  test("Renders the main page", () => {
-    render(<Form />);
+  test("Renders the main page", async () => {
+    await act(async () => {
+      render(<Form />);
+    });
     expect(screen.getByTestId("form-title")).toBeInTheDocument();
   });
 
-  test("Generates CSV file on render", () => {
-    render(<Form />);
+  test("Generates CSV file on render", async () => {
+    await act(async () => {
+      render(<Form />);
+    });
 
     expect(resolveDevelopmentPlanCSV).toHaveBeenCalledTimes(1);
     expect(resolveTimetableEventsCSV).toHaveBeenCalledTimes(1);
   });
 
   test("Updates the CSV when the state changes", async () => {
-    render(<Form />);
+    await act(async () => {
+      render(<Form />);
+    });
 
     await userEvent.type(
       screen.getByTestId(`${stages[1].key}-date-month`),
@@ -55,9 +64,11 @@ describe("all activity users", () => {
     expect(resolveTimetableEventsCSV).toHaveBeenCalledTimes(7);
   });
 
-  test("renders a PlanPreview component", () => {
-    render(<Form />);
+  test("renders a PlanViewer component", async () => {
+    await act(async () => {
+      render(<Form />);
+    });
 
-    expect(PlanViewer).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Plan viewer component")).toBeInTheDocument();
   });
 });

--- a/lib/timetable-visualisation/PlanViewer.tsx
+++ b/lib/timetable-visualisation/PlanViewer.tsx
@@ -25,7 +25,7 @@ export const PlanViewer = ({
   timetableEvents,
 }: PlanViewerProps) => {
   return (
-    <div data-testid="plan-preview">
+    <div data-testid="plan-viewer">
       <div>
         <h1 className="govuk-heading-xl">{name}</h1>
         <p className="govuk-body-l">{description}</p>

--- a/lib/timetable-visualisation/Visualisation.test.tsx
+++ b/lib/timetable-visualisation/Visualisation.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom";
-import { render, waitFor, screen } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import { loadCSV } from "../utils/timetable";
 import { Visualisation } from "./Visualisation";
 import csvToJson from "csvtojson";
@@ -19,45 +19,53 @@ const headersFilepath = "/header";
 describe("Visualisation", () => {
   beforeEach(() => {
     (loadCSV as jest.Mock).mockResolvedValue("");
-    (PlanViewer as jest.Mock).mockReturnValue(<></>);
+    (PlanViewer as jest.Mock).mockReturnValue(<>Plan viewer component</>);
   });
 
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it("renders", () => {
-    render(
-      <Visualisation
-        stagesFilepath={stagesFilePath}
-        headersFilepath={headersFilepath}
-      />
-    );
+  it("renders", async () => {
+    await act(async () => {
+      render(
+        <Visualisation
+          stagesFilepath={stagesFilePath}
+          headersFilepath={headersFilepath}
+        />
+      );
+    });
+
     expect(screen.getByTestId("visualisation")).toBeInTheDocument();
   });
 
   it("calls loadCSV and csvToJson twice on mount", async () => {
-    render(
-      <Visualisation
-        stagesFilepath={stagesFilePath}
-        headersFilepath={headersFilepath}
-      />
-    );
-    await waitFor(() => {
-      expect(loadCSV).toHaveBeenCalledTimes(2);
-      expect(loadCSV).toHaveBeenNthCalledWith(1, stagesFilePath);
-      expect(loadCSV).toHaveBeenNthCalledWith(2, headersFilepath);
-
-      expect(csvToJson).toHaveBeenCalledTimes(2);
+    await act(async () => {
+      render(
+        <Visualisation
+          stagesFilepath={stagesFilePath}
+          headersFilepath={headersFilepath}
+        />
+      );
     });
+
+    expect(loadCSV).toHaveBeenCalledTimes(2);
+    expect(loadCSV).toHaveBeenNthCalledWith(1, stagesFilePath);
+    expect(loadCSV).toHaveBeenNthCalledWith(2, headersFilepath);
+
+    expect(csvToJson).toHaveBeenCalledTimes(2);
   });
-  it("renders a PlanPreview component", () => {
-    render(
-      <Visualisation
-        stagesFilepath={stagesFilePath}
-        headersFilepath={headersFilepath}
-      />
-    );
-    expect(PlanViewer).toHaveBeenCalledTimes(1);
+
+  it("renders a PlanViewer component", async () => {
+    await act(async () => {
+      render(
+        <Visualisation
+          stagesFilepath={stagesFilePath}
+          headersFilepath={headersFilepath}
+        />
+      );
+    });
+
+    expect(screen.getByText("Plan viewer component")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Cleaning up console warnings and errors in tests:
- `act` errors from the testing library
- Old React class methods from the autocomplete component

I looked into the warnings seen at the beginning of the tests but setting the `esModuleInterop` caused errors, so I decided to leave for now