### PR TITLE
SOW-24: update readme to remove reference to component library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Local Plans Timetable
 
-This repository is a component library publishing two components as part of the Local Plans Timetable private beta:
+As part of the Local Plans Timetable private beta, this repository contains:
 
-- **Timetable form:** Used by LPAs to produce timetable data for a local plan that meets the [data standard](https://digital-land.github.io/specification/specification/development-plan/)
+- **Timetable form:** A static form application to be used by LPAs to produce timetable data for a local plan that meets the [data standard](https://digital-land.github.io/specification/specification/development-plan/)
 - **Timetable visualisation:** A tool to visualise timetable data that follows the data standard
 
 See the wiki [here](https://github.com/digital-land/local-plans-timetable/wiki).


### PR DESCRIPTION
Now that the form is a full static application (not just a component), reword the README to avoid calling the repo a component library