### PR TITLE
SOW-24: move stage to pages and add tests

### DIFF
--- a/lib/stories/FormStage.stories.tsx
+++ b/lib/stories/FormStage.stories.tsx
@@ -1,19 +1,19 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { FormStage } from "../timetable-form/FormStage";
+import { StagePage } from "../timetable-form/pages/StagePage";
 
 import "govuk-frontend/dist/govuk/govuk-frontend.min.css";
 
 const meta = {
   title: "Example/FormStage",
-  component: FormStage,
+  component: StagePage,
   // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
   tags: ["autodocs"],
   parameters: {
     // More on how to position stories at: https://storybook.js.org/docs/configure/story-layout
     layout: "fullscreen",
   },
-} satisfies Meta<typeof FormStage>;
+} satisfies Meta<typeof StagePage>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/lib/timetable-form/Form.test.tsx
+++ b/lib/timetable-form/Form.test.tsx
@@ -19,7 +19,7 @@ jest.mock("../validation");
 // This is mocked to avoid the warnings about componentWillMount and componentWillReceiveProps from the accessible-autocomplete component
 jest.mock("./autocomplete/Autocomplete");
 
-describe("all activity users", () => {
+describe("Form", () => {
   beforeEach(() => {
     (resolveDevelopmentPlanCSV as jest.Mock).mockImplementation(() => {});
     (resolveTimetableEventsCSV as jest.Mock).mockImplementation(() => {});
@@ -31,7 +31,7 @@ describe("all activity users", () => {
     jest.clearAllMocks();
   });
 
-  test("Renders the main page", async () => {
+  test("displays title", async () => {
     await act(async () => {
       render(<Form />);
     });

--- a/lib/timetable-form/pages/LPAPage.test.tsx
+++ b/lib/timetable-form/pages/LPAPage.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom";
 import { act, render } from "@testing-library/react";
 import { fetchLPAs } from "../../api";
-import { Form } from "../Form";
+import { LPAPage } from "./LPAPage";
 
 jest.mock("../autocomplete/Autocomplete");
 jest.mock("../../api/");
@@ -17,7 +17,7 @@ describe("LPAPage", () => {
 
   test("Calls fetchLPAs on mount", async () => {
     await act(async () => {
-      render(<Form />);
+      render(<LPAPage />);
     });
     expect(fetchLPAs).toHaveBeenCalledTimes(1);
   });

--- a/lib/timetable-form/pages/StagePage.test.tsx
+++ b/lib/timetable-form/pages/StagePage.test.tsx
@@ -1,0 +1,44 @@
+import "@testing-library/jest-dom";
+import { act, render } from "@testing-library/react";
+import { StagePage } from "./StagePage";
+import { DateInput } from "../../gds-components";
+
+jest.mock("../../gds-components");
+
+describe("StagePage", () => {
+  beforeEach(() => {
+    (DateInput as jest.Mock).mockImplementation(() => <></>);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("Displays one DateInput component when Stage has only start event", async () => {
+    await act(async () => {
+      render(
+        <StagePage
+          title={""}
+          description={undefined}
+          startEvent="timetable-published"
+        />
+      );
+    });
+
+    expect(DateInput).toHaveBeenCalledTimes(1);
+  });
+
+  test("Displays 2 DateInput components when Stage has start and end event", async () => {
+    await act(async () => {
+      render(
+        <StagePage
+          title={""}
+          description={undefined}
+          startEvent={"examination-hearing-start"}
+          endEvent={"examination-hearing-end"}
+        />
+      );
+    });
+    expect(DateInput).toHaveBeenCalledTimes(2);
+  });
+});

--- a/lib/timetable-form/pages/StagePage.tsx
+++ b/lib/timetable-form/pages/StagePage.tsx
@@ -1,24 +1,24 @@
 import { ReactNode, useState } from "react";
 
-import { Button, DateInput, ErrorSummary, TextArea } from "../gds-components";
-import { useValidation } from "./useValidation";
+import { Button, DateInput, ErrorSummary, TextArea } from "../../gds-components";
+import { useValidation } from "../useValidation";
 
 import styles from "./styles.module.css";
-import { TimetableEventKey } from "../constants";
+import { TimetableEventKey } from "../../constants";
 
-interface FormStageProps {
+interface StagePageProps {
   title: string;
   description: ReactNode;
   startEvent: TimetableEventKey;
   endEvent?: TimetableEventKey;
 }
 
-export const FormStage = ({
+export const StagePage = ({
   title,
   description,
   startEvent,
   endEvent,
-}: FormStageProps): JSX.Element => {
+}: StagePageProps): JSX.Element => {
   const [startDate, setStartDate] = useState<string>("");
   const [endDate, setEndDate] = useState<string>("");
   const [additionalInformation, setAdditionalInformation] =


### PR DESCRIPTION
## Changes
- move FormStage to pages/ and rename to StagePage
- add unit tests