### PR TITLE
SOW-24: switch to hash router to support GitHub Pages

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { createBrowserRouter, RouterProvider } from "react-router-dom";
+import { createHashRouter, RouterProvider } from "react-router-dom";
 import {
   LPAPage,
   TitlePage,
@@ -24,48 +24,45 @@ import "./main.css";
 
 import "govuk-frontend/dist/govuk/govuk-frontend.min.css";
 
-const router = createBrowserRouter(
-  [
-    {
-      element: <Page />,
-      children: [
-        {
-          path: PageRoute.Root,
-          element: <CreateTimetablePage />,
-        },
-        {
-          path: PageRoute.UploadTimetable,
-          element: FormPageHoC(UploadTimetablePage, {}),
-        },
-        {
-          path: PageRoute.LPA,
-          element: FormPageHoC(LPAPage, {}),
-        },
-        {
-          path: PageRoute.Title,
-          element: FormPageHoC(TitlePage, {}, validateTitle),
-        },
-        {
-          path: PageRoute.Description,
-          element: FormPageHoC(DescriptionPage, {}, validateDescription),
-        },
-        {
-          path: PageRoute.PublishLocalDevelopmentScheme,
-          element: FormPageHoC(PublishLDSPage, {}, validatePublishLDSEvent),
-        },
-        ...stages.map(({ key, ...otherProps }) => ({
-          path: key,
-          element: FormPageHoC(StagePage, otherProps, validateTimetableStage),
-        })),
-        {
-          path: PageRoute.Export,
-          element: FormPageHoC(ExportPage, {}),
-        },
-      ],
-    },
-  ],
-  { basename: PageRoute.Base }
-);
+const router = createHashRouter([
+  {
+    element: <Page />,
+    children: [
+      {
+        path: PageRoute.Root,
+        element: <CreateTimetablePage />,
+      },
+      {
+        path: PageRoute.UploadTimetable,
+        element: FormPageHoC(UploadTimetablePage, {}),
+      },
+      {
+        path: PageRoute.LPA,
+        element: FormPageHoC(LPAPage, {}),
+      },
+      {
+        path: PageRoute.Title,
+        element: FormPageHoC(TitlePage, {}, validateTitle),
+      },
+      {
+        path: PageRoute.Description,
+        element: FormPageHoC(DescriptionPage, {}, validateDescription),
+      },
+      {
+        path: PageRoute.PublishLocalDevelopmentScheme,
+        element: FormPageHoC(PublishLDSPage, {}, validatePublishLDSEvent),
+      },
+      ...stages.map(({ key, ...otherProps }) => ({
+        path: key,
+        element: FormPageHoC(StagePage, otherProps, validateTimetableStage),
+      })),
+      {
+        path: PageRoute.Export,
+        element: FormPageHoC(ExportPage, {}),
+      },
+    ],
+  },
+]);
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>


### PR DESCRIPTION
Browser router doesn't work in GitHub pages, you'll get a 404 on any non-root page because it's looking for an HTML page with that name. There's no way around this as we can't configure to service the index file at every path. The solution for this is to switch to a hash router, which is a very minor change:

`http://localhost:5173/local-plans-timetable/title-of-local-plan` -> `http://localhost:5173/local-plans-timetable#/title-of-local-plan`