### PR TITLE
SOW-24: go back to browser router

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Build and Deploy
 on:
   push:
     branches:
-      - main
+      - SOW-24/go-back-to-browser-router
 
 jobs:
   lint-and-test:
@@ -28,26 +28,26 @@ jobs:
           folder: dist # The folder that the build script generates files.
           clean: true # Automatically remove deleted files from the deploy branch
           clean-exclude: .nojekyll
-  build-and-deploy-cdn:
-    runs-on: ubuntu-latest
-    needs: lint-and-test
-    steps:
-      - uses: actions/checkout@v4
+  # build-and-deploy-cdn:
+  #   runs-on: ubuntu-latest
+  #   needs: lint-and-test
+  #   steps:
+  #     - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
-        with:
-          node-version: "20.x"
-          cache: "npm"
+  #     - uses: actions/setup-node@v3
+  #       with:
+  #         node-version: "20.x"
+  #         cache: "npm"
 
-      - run: npm ci
+  #     - run: npm ci
 
-      - name: Build CDN component
-        run: npm run build:cdn
+  #     - name: Build CDN component
+  #       run: npm run build:cdn
 
-      - name: Deploy CDN
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          folder: dist-cdn
-          clean: true
-          branch: master
-          clean-exclude: README.md
+  #     - name: Deploy CDN
+  #       uses: JamesIves/github-pages-deploy-action@v4
+  #       with:
+  #         folder: dist-cdn
+  #         clean: true
+  #         branch: master
+  #         clean-exclude: README.md

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "prebuild": "node ./scripts/wrapper-pre-build.cjs",
     "dev": "npm run prebuild && vite --open",
     "build": "tsc && vite build",
+    "postbuild": "node ./scripts/wrapper-post-build.cjs",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "storybook": "storybook dev -p 6006",

--- a/scripts/wrapper-post-build.cjs
+++ b/scripts/wrapper-post-build.cjs
@@ -1,0 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires, no-undef
+const fs = require("fs");
+
+fs.cpSync("dist/index.html", "dist/404.html");

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { createHashRouter, RouterProvider } from "react-router-dom";
+import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import {
   LPAPage,
   TitlePage,
@@ -24,45 +24,48 @@ import "./main.css";
 
 import "govuk-frontend/dist/govuk/govuk-frontend.min.css";
 
-const router = createHashRouter([
-  {
-    element: <Page />,
-    children: [
-      {
-        path: PageRoute.Root,
-        element: <CreateTimetablePage />,
-      },
-      {
-        path: PageRoute.UploadTimetable,
-        element: FormPageHoC(UploadTimetablePage, {}),
-      },
-      {
-        path: PageRoute.LPA,
-        element: FormPageHoC(LPAPage, {}),
-      },
-      {
-        path: PageRoute.Title,
-        element: FormPageHoC(TitlePage, {}, validateTitle),
-      },
-      {
-        path: PageRoute.Description,
-        element: FormPageHoC(DescriptionPage, {}, validateDescription),
-      },
-      {
-        path: PageRoute.PublishLocalDevelopmentScheme,
-        element: FormPageHoC(PublishLDSPage, {}, validatePublishLDSEvent),
-      },
-      ...stages.map(({ key, ...otherProps }) => ({
-        path: key,
-        element: FormPageHoC(StagePage, otherProps, validateTimetableStage),
-      })),
-      {
-        path: PageRoute.Export,
-        element: FormPageHoC(ExportPage, {}),
-      },
-    ],
-  },
-]);
+const router = createBrowserRouter(
+  [
+    {
+      element: <Page />,
+      children: [
+        {
+          path: PageRoute.Root,
+          element: <CreateTimetablePage />,
+        },
+        {
+          path: PageRoute.UploadTimetable,
+          element: FormPageHoC(UploadTimetablePage, {}),
+        },
+        {
+          path: PageRoute.LPA,
+          element: FormPageHoC(LPAPage, {}),
+        },
+        {
+          path: PageRoute.Title,
+          element: FormPageHoC(TitlePage, {}, validateTitle),
+        },
+        {
+          path: PageRoute.Description,
+          element: FormPageHoC(DescriptionPage, {}, validateDescription),
+        },
+        {
+          path: PageRoute.PublishLocalDevelopmentScheme,
+          element: FormPageHoC(PublishLDSPage, {}, validatePublishLDSEvent),
+        },
+        ...stages.map(({ key, ...otherProps }) => ({
+          path: key,
+          element: FormPageHoC(StagePage, otherProps, validateTimetableStage),
+        })),
+        {
+          path: PageRoute.Export,
+          element: FormPageHoC(ExportPage, {}),
+        },
+      ],
+    },
+  ],
+  { basename: PageRoute.Base }
+);
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>


### PR DESCRIPTION
Returning to using a browser router instead of a hash router so we can support the GDS error summary component (which uses URL hashes). The previous issue of loading the app on a non-root page is fixed by the addition of a 404 page which also loads the index.