### PR TITLE
SOW-24: exclude some events from the defaults

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from "uuid";
 import { DevelopmentPlan } from "./types/timetable";
 
+// TODO: When we align the visualisation to the design, we won't need the event names here
 export const developmentPlanTimetableEvents = [
   { name: "Timetable updated", key: "timetable-updated" },
   {
@@ -27,6 +28,10 @@ export const developmentPlanTimetableEvents = [
   {
     name: "Plan found unsound",
     key: "plan-found-unsound",
+  },
+  {
+    name: "Plan not adopted",
+    key: "plan-not-adopted",
   },
 ] as const;
 
@@ -58,8 +63,18 @@ export const DEFAULT_DEVELOPMENT_PLAN: DevelopmentPlan = {
   startDate: "",
 };
 
-export const DEFAULT_TIMETABLE_EVENTS = developmentPlanTimetableEvents.map(
-  ({ key }) => ({
+const eventsToExclude = new Set<TimetableEventKey>([
+  "timetable-updated",
+  "plan-paused",
+  "plan-withdrawn",
+  "plan-found-sound",
+  "plan-found-unsound",
+  "plan-not-adopted",
+]);
+
+export const DEFAULT_TIMETABLE_EVENTS = developmentPlanTimetableEvents
+  .filter(({ key }) => !eventsToExclude.has(key))
+  .map(({ key }) => ({
     reference: uuidv4(),
     name: "",
     developmentPlan: "",
@@ -70,5 +85,4 @@ export const DEFAULT_TIMETABLE_EVENTS = developmentPlanTimetableEvents.map(
     entryDate: getFormattedDate(),
     startDate: getFormattedDate(),
     endDate: "",
-  })
-);
+  }));

--- a/src/pages/stage-page/StagePage.test.tsx
+++ b/src/pages/stage-page/StagePage.test.tsx
@@ -20,7 +20,7 @@ describe("StagePage", () => {
         <StagePage
           title={""}
           description={undefined}
-          startEventKey="plan-paused"
+          startEventKey="plan-submitted-for-examination"
         />
       );
     });
@@ -34,8 +34,8 @@ describe("StagePage", () => {
         <StagePage
           title={""}
           description={undefined}
-          startEventKey={"examination-hearing-start"}
-          endEventKey={"examination-hearing-end"}
+          startEventKey="examination-hearing-start"
+          endEventKey="examination-hearing-end"
         />
       );
     });


### PR DESCRIPTION
Exclude status events and time table updated from the default events created at the start of the journey. There are a few things that we can start to clean up once we've aligned the visualisation to the designs:

- We won't need the event key to name mapping anymore, this is the responsibility of our "stages"
- We won't need to sort the events any more because we won't be relying on their order
   - We will still need to filter out invalidated events