### PR TITLE
SOW-24: ensure timetable updated time is updated on edit

### DIFF
--- a/src/pages/export-page/ExportPage.tsx
+++ b/src/pages/export-page/ExportPage.tsx
@@ -24,7 +24,11 @@ export const ExportPage = () => {
     return [
       ...timetableEvents,
       {
-        reference: uuidv4(),
+        reference:
+          loadedTimetableEvents?.find(
+            ({ developmentPlanEvent }) =>
+              developmentPlanEvent === "timetable-updated"
+          )?.reference ?? uuidv4(),
         name: "",
         developmentPlan: "",
         developmentPlanEvent: "timetable-updated",
@@ -36,7 +40,7 @@ export const ExportPage = () => {
         endDate: "",
       },
     ];
-  }, [timetableEvents]);
+  }, [timetableEvents, loadedTimetableEvents]);
 
   const developmentPlanDownloadLink = useMemo(() => {
     const timetableCSV = resolveDevelopmentPlanCSV(

--- a/src/pages/upload-timetable-page/UploadTimetablePage.tsx
+++ b/src/pages/upload-timetable-page/UploadTimetablePage.tsx
@@ -18,47 +18,58 @@ export const UploadTimetablePage = (): JSX.Element => {
     setLoadedDevelopmentPlan,
   } = useFormContext();
 
-  const handleDevelopmentPlanUpload = useCallback((file: File) => {
-    reader.onload = (event) => {
-      const csvString = event.target?.result?.toString();
+  const handleDevelopmentPlanUpload = useCallback(
+    (file: File) => {
+      reader.onload = (event) => {
+        const csvString = event.target?.result?.toString();
 
-      if (csvString) {
-        const developmentPlan = fromCSVString<DevelopmentPlan>(csvString);
-        setLoadedDevelopmentPlan(developmentPlan);
-        // This assumes the last row is the current row
-        setDevelopmentPlan(developmentPlan.slice(-1)[0]);
-      }
-    };
+        if (csvString) {
+          const developmentPlan = fromCSVString<DevelopmentPlan>(csvString);
+          setLoadedDevelopmentPlan(developmentPlan);
+          // This assumes the last row is the current row
+          setDevelopmentPlan(developmentPlan.slice(-1)[0]);
+        }
+      };
 
-    reader.readAsText(file);
-  }, [setDevelopmentPlan, setLoadedDevelopmentPlan]);
+      reader.readAsText(file);
+    },
+    [setDevelopmentPlan, setLoadedDevelopmentPlan]
+  );
 
-  const handleTimetableUpload = useCallback((file: File) => {
-    reader.onload = (event) => {
-      const csvString = event.target?.result?.toString();
+  const handleTimetableUpload = useCallback(
+    (file: File) => {
+      reader.onload = (event) => {
+        const csvString = event.target?.result?.toString();
 
-      if (csvString) {
-        const loadedEvents = fromCSVString<DevelopmentPlanTimetable>(csvString);
-        setLoadedTimetableEvents(loadedEvents);
-        setTimetableEvents(
-          loadedEvents
-            // This assumes any row with an end date is invalid
-            .filter((event) => !event.endDate)
-            .sort(
-              (a, b) =>
-                developmentPlanTimetableEvents.findIndex(
-                  (s) => s.key === a.developmentPlanEvent
-                ) -
-                developmentPlanTimetableEvents.findIndex(
-                  (s) => s.key === b.developmentPlanEvent
-                )
-            )
-        );
-      }
-    };
+        if (csvString) {
+          const loadedEvents =
+            fromCSVString<DevelopmentPlanTimetable>(csvString);
+          setLoadedTimetableEvents(loadedEvents);
+          setTimetableEvents(
+            loadedEvents
+              // This assumes any row with an end date is invalid
+              .filter(
+                (event) =>
+                  !event.endDate &&
+                  event.developmentPlanEvent !== "timetable-updated"
+              )
+              .sort(
+                (a, b) =>
+                  developmentPlanTimetableEvents.findIndex(
+                    (s) => s.key === a.developmentPlanEvent
+                  ) -
+                  developmentPlanTimetableEvents.findIndex(
+                    (s) => s.key === b.developmentPlanEvent
+                  )
+              )
+          );
+        }
+      };
 
-    reader.readAsText(file);
-  }, [setLoadedTimetableEvents, setTimetableEvents]);
+      reader.readAsText(file);
+    },
+    [setLoadedTimetableEvents, setTimetableEvents]
+  );
 
   return (
     <>


### PR DESCRIPTION
The `timetable-updated` event was never being updated on edit because there was no reference match in the events from the form. This PR:
- Filters out the old event from the form on upload (since this event isn't being edited, the diffing would decide it hadn't changed)
- When creating the new event, use the existing reference if there is one to make sure the old event is invalidated