### PR TITLE
SOW-24: remove @lib alias from lib folder

### DIFF
--- a/lib/timetable-visualisation/PlanViewer.tsx
+++ b/lib/timetable-visualisation/PlanViewer.tsx
@@ -1,14 +1,10 @@
 import { useMemo } from "react";
 
-import { getTimetableEventName } from "@lib/constants";
-import { Tag } from "@lib/gds-components";
-import {
-  getStageProgress,
-  toDefaultLocalDateString,
-} from "@lib/utils/timetable";
+import { getTimetableEventName } from "../constants";
+import { Tag } from "../gds-components";
+import { getStageProgress, toDefaultLocalDateString } from "../utils/timetable";
 import { DevelopmentPlan, DevelopmentPlanTimetable } from "../types/timetable";
 
-import "govuk-frontend/dist/govuk/govuk-frontend.min.css";
 import { stages } from "./stages";
 
 type PlanViewerProps = {


### PR DESCRIPTION
- Remove usage of `@lib` alias from `lib` folder (the alias isn't supported by the CDN build)
- Remove unneeded GDS styles import in `PlanViewer` component