### PR TITLE
SOW-24: how to publish a timetable

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,6 +11,7 @@ import {
   UpdateTimetableStatusPage,
   StatusChangeEventPage,
   CreateTimetablePage,
+  HowToPublishPage,
   ExportPage,
 } from "./pages";
 import { FormPageHoC } from "./pages/FormPageHoc";
@@ -36,6 +37,10 @@ const router = createBrowserRouter(
         {
           path: PageRoute.Root,
           element: <CreateTimetablePage />,
+        },
+        {
+          path: PageRoute.HowToPublish,
+          element: <HowToPublishPage />,
         },
         {
           path: PageRoute.UploadTimetable,

--- a/src/pages/create-timetable-page/CreateTimetablePage.tsx
+++ b/src/pages/create-timetable-page/CreateTimetablePage.tsx
@@ -23,7 +23,12 @@ export const CreateTimetablePage = () => {
     setDevelopmentPlan(DEFAULT_DEVELOPMENT_PLAN);
     setLoadedTimetableEvents(null);
     setLoadedDevelopmentPlan(null);
-  }, [setDevelopmentPlan, setLoadedDevelopmentPlan, setLoadedTimetableEvents, setTimetableEvents]);
+  }, [
+    setDevelopmentPlan,
+    setLoadedDevelopmentPlan,
+    setLoadedTimetableEvents,
+    setTimetableEvents,
+  ]);
 
   return (
     <div className="govuk-grid-row">
@@ -48,7 +53,7 @@ export const CreateTimetablePage = () => {
             <li className={`${styles.appSubnavSectionItem}`}>
               <Link
                 className={`${styles.appSubnavLink} govuk-link  govuk-link--no-underline`}
-                to="#"
+                to={PageRoute.HowToPublish}
                 aria-current="page"
               >
                 How to publish a Local Plan timetable online
@@ -115,7 +120,7 @@ export const CreateTimetablePage = () => {
         <h2 className="govuk-heading-m">Before you start</h2>
         <p className="govuk-body">
           Read our guidance on{" "}
-          <Link className="govuk-link" to="#">
+          <Link className="govuk-link" to={PageRoute.HowToPublish}>
             How to publish a Local Plan online
           </Link>
         </p>

--- a/src/pages/create-timetable-page/CreateTimetablePage.tsx
+++ b/src/pages/create-timetable-page/CreateTimetablePage.tsx
@@ -6,8 +6,8 @@ import {
 import { Link } from "react-router-dom";
 import { PageRoute, Journey } from "../../routes/routes";
 import { useFormContext } from "../../context/use-form-context";
-import styles from "./create-timetable.module.css";
 import { useEffect } from "react";
+import { NavPageWrapper } from "../nav-page-wrapper/NavPageWrapper";
 
 export const CreateTimetablePage = () => {
   const {
@@ -31,110 +31,57 @@ export const CreateTimetablePage = () => {
   ]);
 
   return (
-    <div className="govuk-grid-row">
-      <div className="govuk-grid-column-one-third">
-        <nav
-          className={`${styles.appSubnav}`}
-          aria-labelledby="app-subnav-heading"
+    <NavPageWrapper pageTitle="Create or update a Local Plan timetable">
+      <p className="govuk-body">
+        Use this online form if you work in a Local Planning Authority and need
+        tocreate a new Local Plan timetable or update an existing one.
+      </p>
+      <p className="govuk-body"> You can use this online form to:</p>
+      <ul className="govuk-list govuk-list--bullet">
+        <li>
+          create an accessible, online timetable to publish on your
+          organisation’s website
+        </li>
+        <li>make progress updates for key stages of your existing plan</li>
+        <li>
+          add or make changes to dates in your existing plan. For example, once
+          examination dates are confirmed
+        </li>
+        <li>
+          tell us if the status of your plan has changed. For example, if the
+          plan has been withdrawn
+        </li>
+      </ul>
+      <div>
+        <Link to={PageRoute.LPA} onClick={() => setUserFlow(Journey.Create)}>
+          <Button>Start a new timetable</Button>
+        </Link>
+      </div>
+      <div>
+        <Link
+          to={PageRoute.UploadTimetable}
+          onClick={() => setUserFlow(Journey.Update)}
         >
-          <ul className={`${styles.appSubnavSection}`}>
-            <li className={`${styles.appSubnavSectionItem}`}>
-              Create or update a Local Plan timetable
-            </li>
-            <li className={`${styles.appSubnavSectionItem}`}>
-              <Link
-                className={`${styles.appSubnavLink} govuk-link  govuk-link--no-underline`}
-                to="#"
-                aria-current="page"
-              >
-                Create or update a Local Plan timetable
-              </Link>
-            </li>
-            <li className={`${styles.appSubnavSectionItem}`}>
-              <Link
-                className={`${styles.appSubnavLink} govuk-link  govuk-link--no-underline`}
-                to={PageRoute.HowToPublish}
-                aria-current="page"
-              >
-                How to publish a Local Plan timetable online
-              </Link>
-            </li>
-            <li className={`${styles.appSubnavSectionItem}`}>
-              <Link
-                className={`${styles.appSubnavLink} govuk-link  govuk-link--no-underline`}
-                to="#"
-                aria-current="page"
-              >
-                How to update a Local Plan timetable online
-              </Link>
-            </li>
-            <li className={`${styles.appSubnavSectionItem}`}>
-              <Link
-                className={`${styles.appSubnavLink} govuk-link  govuk-link--no-underline`}
-                to="#"
-                aria-current="page"
-              >
-                Publishing a local plan timetable online: guidance for web teams
-              </Link>
-            </li>
-          </ul>
-        </nav>
+          <Button>Upload and edit an existing timetable CSV</Button>
+        </Link>
       </div>
-      <div className="govuk-grid-column-two-thirds">
-        <h1 className="govuk-heading-xl">
-          Create or update a Local Plan timetable
-        </h1>
-        <p className="govuk-body">
-          Use this online form if you work in a Local Planning Authority and
-          need tocreate a new Local Plan timetable or update an existing one.
-        </p>
-        <p className="govuk-body"> You can use this online form to:</p>
-        <ul className="govuk-list govuk-list--bullet">
-          <li>
-            create an accessible, online timetable to publish on your
-            organisation’s website
-          </li>
-          <li>make progress updates for key stages of your existing plan</li>
-          <li>
-            add or make changes to dates in your existing plan. For example,
-            once examination dates are confirmed
-          </li>
-          <li>
-            tell us if the status of your plan has changed. For example, if the
-            plan has been withdrawn
-          </li>
-        </ul>
-        <div>
-          <Link to={PageRoute.LPA} onClick={() => setUserFlow(Journey.Create)}>
-            <Button>Start a new timetable</Button>
-          </Link>
-        </div>
-        <div>
-          <Link
-            to={PageRoute.UploadTimetable}
-            onClick={() => setUserFlow(Journey.Update)}
-          >
-            <Button>Upload and edit an existing timetable CSV</Button>
-          </Link>
-        </div>
-        <h2 className="govuk-heading-m">Before you start</h2>
-        <p className="govuk-body">
-          Read our guidance on{" "}
-          <Link className="govuk-link" to={PageRoute.HowToPublish}>
-            How to publish a Local Plan online
-          </Link>
-        </p>
-        <p className="govuk-body">
-          Before you fill out the form, consider who else you might need to
-          speak to be able to give accurate timescales. You’ll need to give
-          <b> start and end</b> dates (months and years) for key stages of the
-          local plan.
-        </p>
-        <p className="govuk-body">
-          Based on the dates you enter, the online form will automatically show
-          if a stage is ‘not started’, ‘in progress’ or ‘finished’.
-        </p>
-      </div>
-    </div>
+      <h2 className="govuk-heading-m">Before you start</h2>
+      <p className="govuk-body">
+        Read our guidance on{" "}
+        <Link className="govuk-link" to={PageRoute.HowToPublish}>
+          How to publish a Local Plan online
+        </Link>
+      </p>
+      <p className="govuk-body">
+        Before you fill out the form, consider who else you might need to speak
+        to be able to give accurate timescales. You’ll need to give
+        <b> start and end</b> dates (months and years) for key stages of the
+        local plan.
+      </p>
+      <p className="govuk-body">
+        Based on the dates you enter, the online form will automatically show if
+        a stage is ‘not started’, ‘in progress’ or ‘finished’.
+      </p>
+    </NavPageWrapper>
   );
 };

--- a/src/pages/how-to-publish-page/HowToPublishPage.tsx
+++ b/src/pages/how-to-publish-page/HowToPublishPage.tsx
@@ -1,2 +1,7 @@
-export const HowToPublishPage = () =>
-  "How to publish a Local Plan timetable online";
+import { NavPageWrapper } from "../nav-page-wrapper/NavPageWrapper";
+
+export const HowToPublishPage = () => (
+  <NavPageWrapper pageTitle="How to publish a Local Plan timetable online">
+    Page content
+  </NavPageWrapper>
+);

--- a/src/pages/how-to-publish-page/HowToPublishPage.tsx
+++ b/src/pages/how-to-publish-page/HowToPublishPage.tsx
@@ -159,7 +159,7 @@ export const HowToPublishPage = () => (
       You can{" "}
       <a
         className="govuk-link"
-        href="#" /* TODO: Find the page this is meant to point to */
+        href="https://www.gov.uk/guidance/using-csv-file-format"
       >
         read more about using CSV files on GOV.UK
       </a>

--- a/src/pages/how-to-publish-page/HowToPublishPage.tsx
+++ b/src/pages/how-to-publish-page/HowToPublishPage.tsx
@@ -1,7 +1,186 @@
+import { Link } from "react-router-dom";
+
+import { PageRoute } from "../../routes/routes";
 import { NavPageWrapper } from "../nav-page-wrapper/NavPageWrapper";
 
 export const HowToPublishPage = () => (
   <NavPageWrapper pageTitle="How to publish a Local Plan timetable online">
-    Page content
+    <p className="govuk-body">
+      The guidance is for Local Planning Authorities to create and publish a
+      standardised Local Plan timetable online.
+    </p>
+    <p className="govuk-body">
+      We’ve created an online form to help make it quicker and easier to publish
+      a timetable. We recommend publishing your timetable at the same time
+      you’re preparing to publish your Local Development Scheme (LDS).
+    </p>
+    <p className="govuk-body">Using the online form:</p>
+    <ul className="govuk-list govuk-list--bullet">
+      <li>
+        gives a consistent structure, reducing the amount of data you’ll need to
+        include
+      </li>
+      <li>makes it quicker and easier to update timescales</li>
+      <li>
+        will automatically show if stages within the timetable are ‘not
+        started’, ‘in progress’ or ‘finished’, based on the dates you enter
+      </li>
+      <li>is clearer and more accessible for citizens</li>
+    </ul>
+
+    <h2 className="govuk-heading-m">Why this is important</h2>
+    <p className="govuk-body">
+      Each Local Planning Authority must publish their own Local Plan timetable.
+      It is also responsible for keeping it up-to-date.
+    </p>
+    <p className="govuk-body">
+      Understanding the status of a Local Plan gives confidence to developers
+      and planning professionals. It also gives clarity to citizens. For
+      example, being able to see when they can give their views and take part in
+      consultations on the plan. Publishing your timetable with accurate
+      information can also help reduce requests for status updates, saving time
+      and resources.
+    </p>
+
+    <h2 className="govuk-heading-m">
+      How to publish the timetable using the online form
+    </h2>
+    <p className="govuk-body">
+      Follow these steps to publish the timetable online.
+    </p>
+
+    <h3 className="govuk-heading-s">Before you start</h3>
+    <p className="govuk-body">
+      View the{" "}
+      <Link className="govuk-link" to={PageRoute.Root}>
+        online form you’ll use to create your timetable
+      </Link>
+      .
+    </p>
+    <p className="govuk-body">
+      Before you fill out the form, consider who else you might need to speak to
+      be able to give accurate timescales. You’ll need to give{" "}
+      <strong>start and end dates</strong> (months and years) for key stages.
+    </p>
+    <div className="govuk-inset-text">
+      If you do not know the exact dates when filling out the form, we’ll ask
+      you to give predicted timescales for key stages
+    </div>
+    <p className="govuk-body">The stages you’ll need to complete are:</p>
+    <ul className="govuk-list govuk-list--bullet">
+      <li>Publication - the publish date for the Local Development Scheme</li>
+      <li>
+        Public consultation - start and end dates for the first consultation
+        phase (Regulation 18), where residents can give feedback
+      </li>
+      <li>
+        Draft plan is published - start and end dates for the second
+        consultation phase (Regulation 19) , before the plan is evaluated
+      </li>
+      <li>
+        Submission - the date the plan is submitted to the Planning Inspectorate
+      </li>
+      <li>
+        Independent examination - start and end dates for when the Planning
+        Inspectorate will carry out an independent examination
+      </li>
+      <li>Adoption - the date the plan is adopted</li>
+    </ul>
+
+    <h3 className="govuk-heading-s">
+      Have early conversations to help with publishing your timetable
+    </h3>
+    <p className="govuk-body">
+      If you do not have permission to publish on your organisation’s website,
+      you’ll need to speak to colleagues who can. This is so you’ll be able to
+      publish your timetable later on.
+    </p>
+    <p className="govuk-body">For example, this could be:</p>
+    <ul className="govuk-list govuk-list--bullet">
+      <li>a website manager</li>
+      <li>content editor</li>
+      <li>someone in a technical role, such as a developer</li>
+    </ul>
+    <p className="govuk-body">
+      This colleague will need to have the right permissions be able to access
+      and make changes to your website’s code.
+    </p>
+    <p className="govuk-body">
+      Share the specialist guidance with them:{" "}
+      <Link className="govuk-link" to="#" /* TODO: Add link when page exists */>
+        Publishing a local plan timetable online: guidance for web teams
+      </Link>
+      .
+    </p>
+    <p className="govuk-body">
+      It’s also a good idea to give them as much notice as possible, so they can
+      work with you to schedule publication around other website priorities.
+      Agree a publication date and how you’ll work together to publish.
+    </p>
+
+    <h3 className="govuk-heading-s">
+      Use the online form to create the timetable
+    </h3>
+    <p className="govuk-body">
+      Follow the steps and additional information in the form.
+    </p>
+    <p className="govuk-body">
+      Remember to complete dates for each stage <strong>accurately</strong>. The
+      online form will use the dates entered to show users progress updates for
+      key stages. For example, stages which are ‘in progress’.
+    </p>
+    <p className="govuk-body">
+      You can use the preview function in the form to check your answers and how
+      each of the stages is displayed, including progress made.
+    </p>
+
+    <h3 className="govuk-heading-s">Export the timetable files</h3>
+    <p className="govuk-body">
+      You’ll need to export your timetable once you’ve completed the online
+      form.
+    </p>
+    <p className="govuk-body">
+      When you have completed all the details, you’ll need to export your data
+      as CSV files. You can use these files to generate the timetable on your
+      website.
+    </p>
+    <p className="govuk-body">
+      This includes the ‘Timetable’ file which includes the data you’ve entered
+      for each stage of the timetable <strong>and</strong> the ‘Development
+      plan’ file which includes any additional information and descriptions
+      you’ve entered. You’ll need to export both of these files to be able to
+      publish the timetable. You’ll also need these files to be able to{" "}
+      <Link className="govuk-link" to="#" /* TODO: Add link when page exists */>
+        update a timetable
+      </Link>
+      .
+    </p>
+    <p className="govuk-body">
+      You can{" "}
+      <a
+        className="govuk-link"
+        href="#" /* TODO: Find the page this is meant to point to */
+      >
+        read more about using CSV files on GOV.UK
+      </a>
+      .
+    </p>
+
+    <h3 className="govuk-heading-s">Publish the timetable</h3>
+    <p className="govuk-body">
+      If you have a team who manages content on your organisation’s website,
+      you’ll need to share the CSV files with them. The content editor,
+      developer or colleague in a similar role should then follow the steps in
+      the guidance:{" "}
+      <Link className="govuk-link" to="#" /* TODO: Add link when page exists */>
+        Publishing a local plan timetable online: guidance for web teams
+      </Link>
+      .
+    </p>
+    <p className="govuk-body">
+      You’ll need access to your organisation’s website to be able to publish
+      the timetable. If you can do this yourself, follow the same steps in the
+      publishing guidance.
+    </p>
   </NavPageWrapper>
 );

--- a/src/pages/how-to-publish-page/HowToPublishPage.tsx
+++ b/src/pages/how-to-publish-page/HowToPublishPage.tsx
@@ -1,0 +1,2 @@
+export const HowToPublishPage = () =>
+  "How to publish a Local Plan timetable online";

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -7,4 +7,5 @@ export { UploadTimetablePage } from "./upload-timetable-page/UploadTimetablePage
 export { UpdateTimetableStatusPage } from "./update-timetable-status-page/UpdateTimetableStatusPage";
 export { StatusChangeEventPage } from "./status-change-event-page/StatusChangeEventPage";
 export { CreateTimetablePage } from "./create-timetable-page/CreateTimetablePage";
+export { HowToPublishPage } from "./how-to-publish-page/HowToPublishPage";
 export { ExportPage } from "./export-page/ExportPage";

--- a/src/pages/nav-page-wrapper/NavPageWrapper.module.css
+++ b/src/pages/nav-page-wrapper/NavPageWrapper.module.css
@@ -2,21 +2,21 @@
   border-right: none;
   float: left;
   overflow-x: hidden;
-  width: 210px
+  width: 210px;
 }
 
 .no-flexbox .app-pane-content {
   border-left: 1px solid #b1b4b6;
   margin-left: -1px;
-  overflow-x: hidden
+  overflow-x: hidden;
 }
 
-.app-subnav-toggle+input {
-  display: none
+.app-subnav-toggle + input {
+  display: none;
 }
 
-.app-subnav-toggle+input:checked+.app-pane-subnav {
-  display: block
+.app-subnav-toggle + input:checked + .app-pane-subnav {
+  display: block;
 }
 
 .app-subnav-toggle {
@@ -25,13 +25,13 @@
   position: absolute;
   right: 0;
   text-align: right;
-  top: 10px
+  top: 10px;
 }
 
-@media(min-width: 48.0625em) {
+@media (min-width: 48.0625em) {
   .app-subnav-toggle {
-      display:none;
-      padding: 20px
+    display: none;
+    padding: 20px;
   }
 }
 
@@ -42,33 +42,33 @@
   border: 0 solid #000;
   cursor: pointer;
   display: inline-block;
-  font-family: GDS Transport,arial,sans-serif;
+  font-family: GDS Transport, arial, sans-serif;
   font-size: 16px;
   font-size: 1rem;
   font-size: 19px;
   font-weight: 400;
   line-height: 1.25;
-  margin-top: 40px
+  margin-top: 40px;
 }
 
 @media print {
   .app-subnav-toggle-button {
-      font-family: sans-serif
+    font-family: sans-serif;
   }
 }
 
-@media(min-width: 40.0625em) {
+@media (min-width: 40.0625em) {
   .app-subnav-toggle-button {
-      font-size:19px;
-      font-size: 1.1875rem;
-      line-height: 1.3157894737
+    font-size: 19px;
+    font-size: 1.1875rem;
+    line-height: 1.3157894737;
   }
 }
 
 @media print {
   .app-subnav-toggle-button {
-      font-size: 14pt;
-      line-height: 1.15
+    font-size: 14pt;
+    line-height: 1.15;
   }
 }
 
@@ -76,105 +76,108 @@
   background-color: #fd0;
   -webkit-box-decoration-break: clone;
   box-decoration-break: clone;
-  box-shadow: 0 -2px #fd0,0 4px #0b0c0c;
+  box-shadow: 0 -2px #fd0, 0 4px #0b0c0c;
   color: #0b0c0c;
   outline: 3px solid transparent;
-  text-decoration: none
+  text-decoration: none;
 }
 
 .app-subnav-toggle-button:after {
   border-color: #0b0c0c;
   border-style: solid;
   border-width: 8.66px 5px 0;
-  -webkit-clip-path: polygon(0 0,50% 100%,100% 0);
-  clip-path: polygon(0 0,50% 100%,100% 0);
+  -webkit-clip-path: polygon(0 0, 50% 100%, 100% 0);
+  clip-path: polygon(0 0, 50% 100%, 100% 0);
   content: "";
   display: inline-block;
   height: 0;
   margin-left: 5px;
-  width: 0
+  width: 0;
 }
 
 .app-subnav-toggle.active .app-subnav-toggle-button:after {
-  transform: rotate(180deg)
+  transform: rotate(180deg);
 }
 
-.app-pane-subnav .govuk-heading-m>a:active,.app-pane-subnav .govuk-heading-m>a:hover,.app-pane-subnav .govuk-heading-m>a:visited {
-  color: #1d70b8
+.app-pane-subnav .govuk-heading-m > a:active,
+.app-pane-subnav .govuk-heading-m > a:hover,
+.app-pane-subnav .govuk-heading-m > a:visited {
+  color: #1d70b8;
 }
 
-.app-pane-subnav .govuk-heading-m>a:focus {
+.app-pane-subnav .govuk-heading-m > a:focus {
   background-color: #fd0;
   outline: 3px solid #fd0;
-  outline-offset: 0
+  outline-offset: 0;
 }
 
-@media(max-width: 48.0525em) {
+@media (max-width: 48.0525em) {
   .app-pane-subnav {
-      display:block
+    display: block;
   }
 }
 
-.app-pane-subnav .js-enabled [hidden],.js-enabled .app-pane-subnav[hidden] {
-  display: none
+.app-pane-subnav .js-enabled [hidden],
+.js-enabled .app-pane-subnav[hidden] {
+  display: none;
 }
 
 .app-subnav {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  font-family: GDS Transport,arial,sans-serif;
+  font-family: GDS Transport, arial, sans-serif;
   font-size: 16px;
   font-size: 1rem;
   font-weight: 400;
-  line-height: 1.25
+  line-height: 1.25;
 }
 
 @media print {
   .app-subnav {
-      font-family: sans-serif
+    font-family: sans-serif;
   }
 }
 
-@media(min-width: 40.0625em) {
+@media (min-width: 40.0625em) {
   .app-subnav {
-      font-size:19px;
-      font-size: 1.1875rem;
-      line-height: 1.3157894737
+    font-size: 19px;
+    font-size: 1.1875rem;
+    line-height: 1.3157894737;
   }
 }
 
 @media print {
   .app-subnav {
-      font-size: 14pt;
-      line-height: 1.15
+    font-size: 14pt;
+    line-height: 1.15;
   }
 }
 
 .app-subnav-section {
   border-bottom: 1px solid #b1b4b6;
   list-style-type: none;
-  padding: 0 0 20px
+  padding: 0 0 20px;
 }
 
 .app-subnav-section:last-child {
-  border-bottom: none
+  border-bottom: none;
 }
 
 .app-subnav-link {
   display: inline-block;
   padding: 15px 0;
-  text-decoration: none
+  text-decoration: none;
 }
 
-@media(min-width: 48.0625em) {
+@media (min-width: 48.0625em) {
   .app-subnav-link {
-      padding:10px 20px 10px 0
+    padding: 10px 20px 10px 0;
   }
 
   .app-subnav-link:hover {
-      border-left: 4px solid #003078;
-      margin-left: -14px;
-      padding-left: 10px
+    border-left: 4px solid #003078;
+    margin-left: -14px;
+    padding-left: 10px;
   }
 }
 
@@ -182,9 +185,9 @@
   background-color: #fff;
   border-left: 4px solid #1d70b8;
   margin-left: -14px;
-  padding-left: 10px
+  padding-left: 10px;
 }
 
 .app-subnav-section-item--current .app-subnav-link {
-  font-weight: 700
+  font-weight: 700;
 }

--- a/src/pages/nav-page-wrapper/NavPageWrapper.tsx
+++ b/src/pages/nav-page-wrapper/NavPageWrapper.tsx
@@ -1,0 +1,66 @@
+import { Link } from "react-router-dom";
+
+import { PageRoute } from "../../routes/routes";
+import styles from "./NavPageWrapper.module.css";
+
+interface NavPageWrapperProps {
+  children: React.ReactNode;
+  pageTitle: string;
+}
+
+export const NavPageWrapper = ({
+  children,
+  pageTitle,
+}: NavPageWrapperProps) => (
+  <div className="govuk-grid-row">
+    <div className="govuk-grid-column-one-third">
+      <nav className={styles.appSubnav} aria-labelledby="app-subnav-heading">
+        <ul className={styles.appSubnavSection}>
+          <li className={styles.appSubnavSectionItem}>
+            Create or update a Local Plan timetable
+          </li>
+          <li className={styles.appSubnavSectionItem}>
+            <Link
+              className={`${styles.appSubnavLink} govuk-link  govuk-link--no-underline`}
+              to={PageRoute.Root}
+              aria-current="page"
+            >
+              Create or update a Local Plan timetable
+            </Link>
+          </li>
+          <li className={styles.appSubnavSectionItem}>
+            <Link
+              className={`${styles.appSubnavLink} govuk-link  govuk-link--no-underline`}
+              to={PageRoute.HowToPublish}
+              aria-current="page"
+            >
+              How to publish a Local Plan timetable online
+            </Link>
+          </li>
+          <li className={styles.appSubnavSectionItem}>
+            <Link
+              className={`${styles.appSubnavLink} govuk-link  govuk-link--no-underline`}
+              to="#"
+              aria-current="page"
+            >
+              How to update a Local Plan timetable online
+            </Link>
+          </li>
+          <li className={styles.appSubnavSectionItem}>
+            <Link
+              className={`${styles.appSubnavLink} govuk-link  govuk-link--no-underline`}
+              to="#"
+              aria-current="page"
+            >
+              Publishing a local plan timetable online: guidance for web teams
+            </Link>
+          </li>
+        </ul>
+      </nav>
+    </div>
+    <div className="govuk-grid-column-two-thirds">
+      <h1 className="govuk-heading-xl">{pageTitle}</h1>
+      {children}
+    </div>
+  </div>
+);

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -1,6 +1,7 @@
 export enum PageRoute {
   Base = "/local-plans-timetable",
   Root = "/",
+  HowToPublish = "/how-to-publish-a-timetable",
   LPA = "/what-is-your-local-authority",
   Title = "/title-of-local-plan",
   Description = "/local-plan-description",


### PR DESCRIPTION
This PR add the how to publish a timetable page and also extracts the nav into its own component. A couple of things to note:

- I've skipped the link that should appear after the first set of bullet points
   - This would link to a real example of the visualisation, I'll create a ticket for this to prioritise
- 3 of the links point to content pages that don't exist yet, we'll add those in the relevant tickets
- We've made an assumption on where the CSV info link should point, I'll make a point to confirm this but we've got the go ahead to put this in for now