### PR TITLE
SOW-24: use lastUpdatedDate to derive event statuses

### DIFF
--- a/lib/timetable-visualisation/PlanViewer.tsx
+++ b/lib/timetable-visualisation/PlanViewer.tsx
@@ -125,7 +125,15 @@ export const PlanViewer = ({
                 <div className="govuk-!-display-inline govuk-!-margin-right-3">
                   {name}
                 </div>
-                <Tag label={getStageProgress(startDate, endDate)} />
+                {updatedEvent && (
+                  <Tag
+                    label={getStageProgress(
+                      updatedEvent.eventDate,
+                      startDate,
+                      endDate
+                    )}
+                  />
+                )}
                 <div className="govuk-body govuk-!-margin-top-5">{info}</div>
               </th>
               <td className="govuk-table__cell govuk-!-padding-top-6">

--- a/lib/utils/timetable.test.ts
+++ b/lib/utils/timetable.test.ts
@@ -451,66 +451,61 @@ describe("resolveDevelopmentPlanCSV", () => {
   });
 });
 
+interface StageProgressTestCase {
+  lastUpdatedDate: string;
+  startDate: string;
+  endDate?: string;
+  expectedProgress: string;
+}
+
+const stageProgressTestCases: StageProgressTestCase[] = [
+  {
+    lastUpdatedDate: "2024-02-07T09:03:53.514Z",
+    startDate: "2024-03-02",
+    expectedProgress: "NOT STARTED",
+  },
+  {
+    lastUpdatedDate: "2024-02-07T09:03:53.514Z",
+    startDate: "2024-03",
+    expectedProgress: "NOT STARTED",
+  },
+  {
+    lastUpdatedDate: "2024-02-07T09:03:53.514Z",
+    startDate: "2024-01-02",
+    expectedProgress: "FINISHED",
+  },
+  {
+    lastUpdatedDate: "2024-02-07T09:03:53.514Z",
+    startDate: "2024-01",
+    expectedProgress: "FINISHED",
+  },
+  {
+    lastUpdatedDate: "2024-02-07T09:03:53.514Z",
+    startDate: "2024-03",
+    endDate: "2024-06",
+    expectedProgress: "NOT STARTED",
+  },
+  {
+    lastUpdatedDate: "2024-02-07T09:03:53.514Z",
+    startDate: "2024-01",
+    endDate: "2024-06",
+    expectedProgress: "IN PROGRESS",
+  },
+  {
+    lastUpdatedDate: "2024-02-07T09:03:53.514Z",
+    startDate: "2023-11",
+    endDate: "2024-01",
+    expectedProgress: "FINISHED",
+  },
+];
+
 describe("getStageProgress", () => {
-  test("returns IN PROGRESS when startDate is current date", () => {
-    const startDate = new Date();
+  test.each(stageProgressTestCases)(
+    "returns the correct progress status ($expectedProgress)",
+    ({ lastUpdatedDate, startDate, endDate, expectedProgress }) => {
+      const progress = getStageProgress(lastUpdatedDate, startDate, endDate);
 
-    const progress = getStageProgress(startDate.toISOString());
-
-    expect(progress).toBe("IN PROGRESS");
-  });
-
-  test("returns NOT STARTED when startDate is in the future", () => {
-    const startDate = new Date();
-
-    startDate.setMonth(startDate.getMonth() + 1);
-
-    const progress = getStageProgress(startDate.toISOString());
-
-    expect(progress).toBe("NOT STARTED");
-  });
-
-  test("returns FINISHED when startDate is in the past and there is no endDate", () => {
-    const startDate = new Date();
-
-    startDate.setMonth(startDate.getMonth() - 1);
-
-    const progress = getStageProgress(startDate.toISOString());
-
-    expect(progress).toBe("FINISHED");
-  });
-
-  test("returns IN PROGRESS when startDate is in the past and endDate is in the future date", () => {
-    const startDate = new Date();
-
-    startDate.setMonth(startDate.getMonth() - 1);
-
-    const endDate = new Date();
-
-    endDate.setMonth(startDate.getMonth() + 1);
-
-    const progress = getStageProgress(
-      startDate.toISOString(),
-      endDate.toISOString()
-    );
-
-    expect(progress).toBe("IN PROGRESS");
-  });
-
-  test("returns FINISHED when endDate date is in the past", () => {
-    const startDate = new Date();
-
-    startDate.setMonth(startDate.getMonth() - 2);
-
-    const endDate = new Date();
-
-    endDate.setMonth(startDate.getMonth() - 2);
-
-    const progress = getStageProgress(
-      startDate.toISOString(),
-      endDate.toISOString()
-    );
-
-    expect(progress).toBe("FINISHED");
-  });
+      expect(progress).toBe(expectedProgress);
+    }
+  );
 });

--- a/lib/utils/timetable.ts
+++ b/lib/utils/timetable.ts
@@ -119,21 +119,22 @@ export const toDefaultLocalDateString = (dateString: string) => {
 type StageProgress = "IN PROGRESS" | "FINISHED" | "NOT STARTED";
 
 export const getStageProgress = (
+  lastUpdatedDate: string,
   startEventDate: string,
   endEventDate?: string
 ): StageProgress => {
   const startDate = new Date(startEventDate);
-  const currentDate = new Date();
+  const referenceDate = new Date(lastUpdatedDate);
 
-  if (startDate.getTime() > currentDate.getTime()) return "NOT STARTED";
+  if (startDate.getTime() > referenceDate.getTime()) return "NOT STARTED";
 
   if (!endEventDate) {
-    if (startDate.getTime() < currentDate.getTime()) return "FINISHED";
+    if (startDate.getTime() < referenceDate.getTime()) return "FINISHED";
     else return "IN PROGRESS";
   }
   const endDate = new Date(endEventDate);
 
-  if (endDate.getTime() < currentDate.getTime()) return "FINISHED";
+  if (endDate.getTime() < referenceDate.getTime()) return "FINISHED";
   else return "IN PROGRESS";
 };
 


### PR DESCRIPTION
The event statuses are now driven by the last updated date instead of the current date