### PR TITLE
SOW-24: refine status tag behaviour

### DIFF
--- a/lib/gds-components/index.ts
+++ b/lib/gds-components/index.ts
@@ -7,4 +7,5 @@ export { TextArea } from "./text-area/TextArea";
 export { Header } from "./header/Header";
 export { Footer } from "./footer/Footer";
 export { Tag } from "./tag/Tag";
+export type { TagLabel } from "./tag/Tag";
 export { NotificationBanner } from "./notification-banner/NotificationBanner";

--- a/lib/gds-components/tag/Tag.tsx
+++ b/lib/gds-components/tag/Tag.tsx
@@ -2,8 +2,10 @@
  * GDS component: https://design-system.service.gov.uk/components/tag/
  */
 
-export type TagProps = {
-  label: "IN PROGRESS" | "FINISHED" | "NOT STARTED";
+export type TagLabel = "IN PROGRESS" | "FINISHED" | "NOT STARTED";
+
+type TagProps = {
+  label: TagLabel;
 };
 
 export const Tag = ({ label }: TagProps): JSX.Element => {

--- a/lib/timetable-visualisation/PlanViewer.tsx
+++ b/lib/timetable-visualisation/PlanViewer.tsx
@@ -18,9 +18,8 @@ type PlanViewerProps = {
 
 type StagePreviewInfo = {
   name: string;
-  startDate: string;
-  endDate?: string;
-  info?: string;
+  startEvent: DevelopmentPlanTimetable;
+  endEvent?: DevelopmentPlanTimetable;
 };
 
 export const PlanViewer = ({
@@ -47,11 +46,11 @@ export const PlanViewer = ({
     throw new Error("published event not found");
   }
 
-  const stagesInfo = useMemo(
+  const stagesInfo = useMemo<StagePreviewInfo[]>(
     () => [
       {
         name: "Local Development Scheme Published",
-        startDate: publishedEvent.eventDate,
+        startEvent: publishedEvent,
       },
       ...stages.map<StagePreviewInfo>((stage) => {
         const startEvent = timetableEvents.find(
@@ -67,9 +66,8 @@ export const PlanViewer = ({
         }
         return {
           name: stage.title,
-          startDate: startEvent.eventDate,
-          endDate: endEvent?.eventDate,
-          info: startEvent.notes,
+          startEvent,
+          endEvent,
         };
       }),
     ],
@@ -116,7 +114,7 @@ export const PlanViewer = ({
           </tr>
         </thead>
         <tbody className="govuk-table__body">
-          {stagesInfo.map(({ name, startDate, endDate, info }) => (
+          {stagesInfo.map(({ name, startEvent, endEvent }) => (
             <tr className="govuk-table__row" key={name}>
               <th
                 scope="row"
@@ -125,23 +123,27 @@ export const PlanViewer = ({
                 <div className="govuk-!-display-inline govuk-!-margin-right-3">
                   {name}
                 </div>
-                {updatedEvent && (
-                  <Tag
-                    label={getStageProgress(
-                      updatedEvent.eventDate,
-                      startDate,
-                      endDate
-                    )}
-                  />
-                )}
-                <div className="govuk-body govuk-!-margin-top-5">{info}</div>
+                {updatedEvent &&
+                  startEvent.eventDate &&
+                  (!endEvent || endEvent.eventDate) && (
+                    <Tag
+                      label={getStageProgress(
+                        updatedEvent.eventDate,
+                        startEvent.eventDate,
+                        endEvent?.eventDate
+                      )}
+                    />
+                  )}
+                <div className="govuk-body govuk-!-margin-top-5">
+                  {startEvent.notes}
+                </div>
               </th>
               <td className="govuk-table__cell govuk-!-padding-top-6">
-                {endDate
+                {endEvent?.eventDate
                   ? `${toDefaultLocalDateString(
-                      startDate
-                    )} to ${toDefaultLocalDateString(endDate)}`
-                  : toDefaultLocalDateString(startDate)}
+                      startEvent.eventDate
+                    )} to ${toDefaultLocalDateString(endEvent?.eventDate)}`
+                  : toDefaultLocalDateString(startEvent.eventDate)}
               </td>
             </tr>
           ))}

--- a/lib/utils/timetable.test.ts
+++ b/lib/utils/timetable.test.ts
@@ -459,16 +459,7 @@ interface StageProgressTestCase {
 }
 
 const stageProgressTestCases: StageProgressTestCase[] = [
-  {
-    lastUpdatedDate: "2024-02-07T09:03:53.514Z",
-    startDate: "2024-03-02",
-    expectedProgress: "NOT STARTED",
-  },
-  {
-    lastUpdatedDate: "2024-02-07T09:03:53.514Z",
-    startDate: "2024-03",
-    expectedProgress: "NOT STARTED",
-  },
+  // Start date only - With day
   {
     lastUpdatedDate: "2024-02-07T09:03:53.514Z",
     startDate: "2024-01-02",
@@ -476,26 +467,66 @@ const stageProgressTestCases: StageProgressTestCase[] = [
   },
   {
     lastUpdatedDate: "2024-02-07T09:03:53.514Z",
+    startDate: "2024-02-07",
+    expectedProgress: "FINISHED",
+  },
+  {
+    lastUpdatedDate: "2024-02-07T09:03:53.514Z",
+    startDate: "2024-03-02",
+    expectedProgress: "NOT STARTED",
+  },
+  // Start date only - Without day
+  {
+    lastUpdatedDate: "2024-02-07T09:03:53.514Z",
     startDate: "2024-01",
+    expectedProgress: "FINISHED",
+  },
+  {
+    lastUpdatedDate: "2024-02-07T09:03:53.514Z",
+    startDate: "2024-02",
     expectedProgress: "FINISHED",
   },
   {
     lastUpdatedDate: "2024-02-07T09:03:53.514Z",
     startDate: "2024-03",
-    endDate: "2024-06",
+    expectedProgress: "NOT STARTED",
+  },
+  // Start and end events
+  {
+    lastUpdatedDate: "2024-02-07T09:03:53.514Z",
+    startDate: "2023-12",
+    endDate: "2024-01",
+    expectedProgress: "FINISHED",
+  },
+  {
+    lastUpdatedDate: "2024-02-07T09:03:53.514Z",
+    startDate: "2024-03",
+    endDate: "2024-04",
     expectedProgress: "NOT STARTED",
   },
   {
     lastUpdatedDate: "2024-02-07T09:03:53.514Z",
     startDate: "2024-01",
-    endDate: "2024-06",
+    endDate: "2024-03",
     expectedProgress: "IN PROGRESS",
   },
   {
     lastUpdatedDate: "2024-02-07T09:03:53.514Z",
-    startDate: "2023-11",
-    endDate: "2024-01",
-    expectedProgress: "FINISHED",
+    startDate: "2024-02",
+    endDate: "2024-03",
+    expectedProgress: "IN PROGRESS",
+  },
+  {
+    lastUpdatedDate: "2024-02-07T09:03:53.514Z",
+    startDate: "2024-01",
+    endDate: "2024-02",
+    expectedProgress: "IN PROGRESS",
+  },
+  {
+    lastUpdatedDate: "2024-02-07T09:03:53.514Z",
+    startDate: "2024-02",
+    endDate: "2024-02",
+    expectedProgress: "IN PROGRESS",
   },
 ];
 

--- a/lib/utils/timetable.ts
+++ b/lib/utils/timetable.ts
@@ -134,7 +134,9 @@ export const getStageProgress = (
   const referenceDate = new Date(
     getDatePartFromISOString(lastUpdatedDate, includeDays)
   );
-  const endDate = endEventDate ? new Date(endEventDate) : null;
+  const endDate = endEventDate
+    ? new Date(getDatePartFromISOString(endEventDate, includeDays))
+    : null;
 
   if (!endDate) {
     return startDate.getTime() <= referenceDate.getTime()

--- a/lib/utils/timetable.ts
+++ b/lib/utils/timetable.ts
@@ -1,5 +1,6 @@
 import { v4 as uuidv4 } from "uuid";
 
+import { TagLabel } from "@lib/gds-components";
 import { TimetableEventKey, getFormattedDate } from "../constants";
 import { DevelopmentPlan, DevelopmentPlanTimetable } from "../types/timetable";
 
@@ -116,26 +117,41 @@ export const toDefaultLocalDateString = (dateString: string) => {
   });
 };
 
-type StageProgress = "IN PROGRESS" | "FINISHED" | "NOT STARTED";
+const getDatePartFromISOString = (isoString: string, includeDays: boolean) => {
+  const date = isoString.split("T")[0];
+  return includeDays ? date : date.split("-").slice(0, 2).join("-");
+};
 
 export const getStageProgress = (
   lastUpdatedDate: string,
   startEventDate: string,
   endEventDate?: string
-): StageProgress => {
-  const startDate = new Date(startEventDate);
-  const referenceDate = new Date(lastUpdatedDate);
+): TagLabel => {
+  const includeDays = startEventDate.split("-").length > 2;
+  const startDate = new Date(
+    getDatePartFromISOString(startEventDate, includeDays)
+  );
+  const referenceDate = new Date(
+    getDatePartFromISOString(lastUpdatedDate, includeDays)
+  );
+  const endDate = endEventDate ? new Date(endEventDate) : null;
 
-  if (startDate.getTime() > referenceDate.getTime()) return "NOT STARTED";
-
-  if (!endEventDate) {
-    if (startDate.getTime() < referenceDate.getTime()) return "FINISHED";
-    else return "IN PROGRESS";
+  if (!endDate) {
+    return startDate.getTime() <= referenceDate.getTime()
+      ? "FINISHED"
+      : "NOT STARTED";
   }
-  const endDate = new Date(endEventDate);
 
-  if (endDate.getTime() < referenceDate.getTime()) return "FINISHED";
-  else return "IN PROGRESS";
+  if (
+    startDate.getTime() <= referenceDate.getTime() &&
+    endDate.getTime() >= referenceDate.getTime()
+  ) {
+    return "IN PROGRESS";
+  }
+
+  return endDate.getTime() < referenceDate.getTime()
+    ? "FINISHED"
+    : "NOT STARTED";
 };
 
 export const getStatusChangeMessage = (key: TimetableEventKey): string => {


### PR DESCRIPTION
Changes to the behaviour of what status tags show in what situation after speaking to Emma A.

**General note:** The `timetable-updated` event is captured as a full ISO string (with the time) but when we're using it to calculate the tags, we should only be using the date portion

### Scenarios discussed

These are the scenarios discussed with Emma, split into events that are part of a stage and individual date events (i.e. not part of a stage). We broadly agreed that we'll only show a tag if all the information is present, i.e. all dates that were asked for are provided.

**Start event only**
- No event date given -> No tag
- Event date is before last updated date -> `FINISHED`
- Event date is the same as last updated date -> `FINISHED`
- Event date is after last updated date -> `NOT STARTED`

**Start event and end event**
- No event dates given -> No tag
- Only start event date provided -> No tag
- End event date but no start -> No tag
- Both event dates provided:
   - Both event dates are before last updated -> `FINISHED`
   - Both event dates are after last updated date -> `NOT STARTED`
   - Start event date is before last updated date, end event date is after last updated date -> `IN PROGRESS`
   - Start event date is on last updated date -> `IN PROGRESS`
   - End event date is on last updated date -> `IN PROGRESS`
   - Both event dates are on last updated date -> `IN PROGRESS`
 
Since the stages are given as `YYYY-MM` and the update date is given as `YYYY-MM-DD`, start dates are assumed as the first day of the month and end dates are assumed as the last. If we had date of `2024-05` and last updated was `2024-05-12`, we'd consider the date started if it's a start date or not ended if it's an end date. A couple of observations on this behaviour:
- If the user is updating the timetable in the month of the **start date**, it will always be `IN PROGRESS` but it's possible they could have **not started**
- If the user is updated the timetable in the month of the **end date**, it will allways be `IN PROGRESS` but it's possible they could have **finished**