### PR TITLE
SOW-24: use kebab-case for CSV headers

### DIFF
--- a/assets/development-plan.csv
+++ b/assets/development-plan.csv
@@ -1,2 +1,2 @@
-reference,name,description,developmentPlanType,periodStartDate,periodEndDate,developmentPlanGeography,documentationUrl,organisations,entryDate,startDate,endDate,timetableEvents
+reference,name,description,development-plan-type,period-start-date,period-end-date,development-plan-geography,documentation-url,organisations,entry-date,start-date,end-date,timetable-events
 bc1d31cc-a331-408a-8780-ac32ad930bfc,Birmingham New Local Plan,We are working on a new Local Plan for Birmingham which will guide how the city will develop in the future and provide policies to guide decisions on development proposals and planning applications up to 2042.,type,2023-01-05,2023-01-05,geography,,Birmingham LPA,2023-01-05,2023-01-05,2023-01-05,

--- a/assets/timetable.csv
+++ b/assets/timetable.csv
@@ -1,4 +1,4 @@
-reference,name,developmentPlan,developmentPlanEvent,eventDate,notes,organisation,entryDate,startDate,endDate
+reference,name,development-plan,development-plan-event,event-date,notes,organisation,entry-date,start-date,end-date
 39b7f5e2-beba-43d7-b20d-d9ca3b710f80,dorcester-new-local-plan,bc1d31cc-a331-408a-8780-ac32ad930bfc,timetable-updated,2024-01-05,,,2024-02-02T15:46:14.144Z,2024-02-02T15:46:14.144Z,
 7336edfb-8db3-4bbc-806f-4a0895cdeea6,dorcester-new-local-plan,bc1d31cc-a331-408a-8780-ac32ad930bfc,local-development-scheme-published,2024-01-05,,,2024-02-02T15:46:14.144Z,2024-02-02T15:46:14.144Z,
 267645e9-7643-4d00-a33c-cebc39e898ef,dorcester-new-local-plan,bc1d31cc-a331-408a-8780-ac32ad930bfc,public-consultation-start,2024-01,This is the first opportunity for people in the community to share local priorities and feedback on the policy areas that will underpin the Local Plan.,,2024-02-02T15:46:14.144Z,2024-02-02T15:46:14.144Z,

--- a/lib/utils/timetable.test.ts
+++ b/lib/utils/timetable.test.ts
@@ -2,7 +2,9 @@ import { v4 as uuidv4 } from "uuid";
 
 import { DevelopmentPlan, DevelopmentPlanTimetable } from "../types/timetable";
 import {
+  camelCaseToKebabCase,
   getStageProgress,
+  kebabCaseToCamelCase,
   resolveDevelopmentPlanCSV,
   resolveTimetableEventsCSV,
 } from "./timetable";
@@ -539,4 +541,22 @@ describe("getStageProgress", () => {
       expect(progress).toBe(expectedProgress);
     }
   );
+});
+
+describe("camelCaseToKebabCase", () => {
+  test("returns kebab-case string", () => {
+    const input = "camelCaseString";
+    const expectedResult = "camel-case-string";
+
+    expect(camelCaseToKebabCase(input)).toBe(expectedResult);
+  });
+});
+
+describe("kebabCaseToCamelCase", () => {
+  test("returns camelCase string", () => {
+    const input = "kebab-case-string";
+    const expectedResult = "kebabCaseString";
+
+    expect(kebabCaseToCamelCase(input)).toBe(expectedResult);
+  });
 });

--- a/lib/utils/timetable.test.ts
+++ b/lib/utils/timetable.test.ts
@@ -54,9 +54,9 @@ const eventsTestCases: EventsTestCase[] = [
     ],
     loadedData: null,
     expectedCSV:
-      "reference,name,developmentPlan,developmentPlanEvent,eventDate,notes,organisation,entryDate,startDate,endDate\r\n" +
-      "1,name,development-plan,public-consultation-start,2023-01-01,,organisation,2023-01-01T00:00:00.000Z,2023-01-01T00:00:00.000Z,\r\n" +
-      "2,name,development-plan,examination-hearing-start,2023-01-02,,organisation,2023-01-01T00:00:00.000Z,2023-01-01T00:00:00.000Z,",
+      "development-plan,development-plan-event,end-date,entry-date,event-date,name,notes,organisation,reference,start-date\r\n" +
+      "development-plan,public-consultation-start,,2023-01-01T00:00:00.000Z,2023-01-01,name,,organisation,1,2023-01-01T00:00:00.000Z\r\n" +
+      "development-plan,examination-hearing-start,,2023-01-01T00:00:00.000Z,2023-01-02,name,,organisation,2,2023-01-01T00:00:00.000Z",
   },
   {
     name: "loaded events with no changes",
@@ -113,9 +113,9 @@ const eventsTestCases: EventsTestCase[] = [
       },
     ],
     expectedCSV:
-      "reference,name,developmentPlan,developmentPlanEvent,eventDate,notes,organisation,entryDate,startDate,endDate\r\n" +
-      "1,name,development-plan,public-consultation-start,2023-01-01,,organisation,2023-01-01T00:00:00.000Z,2023-01-01T00:00:00.000Z,\r\n" +
-      "2,name,development-plan,examination-hearing-start,2023-01-02,,organisation,2023-01-01T00:00:00.000Z,2023-01-01T00:00:00.000Z,",
+      "development-plan,development-plan-event,end-date,entry-date,event-date,name,notes,organisation,reference,start-date\r\n" +
+      "development-plan,public-consultation-start,,2023-01-01T00:00:00.000Z,2023-01-01,name,,organisation,1,2023-01-01T00:00:00.000Z\r\n" +
+      "development-plan,examination-hearing-start,,2023-01-01T00:00:00.000Z,2023-01-02,name,,organisation,2,2023-01-01T00:00:00.000Z",
   },
   {
     name: "loaded events with changes",
@@ -172,10 +172,10 @@ const eventsTestCases: EventsTestCase[] = [
       },
     ],
     expectedCSV:
-      "reference,name,developmentPlan,developmentPlanEvent,eventDate,notes,organisation,entryDate,startDate,endDate\r\n" +
-      "1,name,development-plan,public-consultation-start,2023-01-01,,organisation,2023-01-01T00:00:00.000Z,2023-01-01T00:00:00.000Z,\r\n" +
-      `2,name,development-plan,examination-hearing-start,2023-01-03,,organisation,2023-01-01T00:00:00.000Z,2023-01-01T00:00:00.000Z,${currentDate}\r\n` +
-      `3,name,development-plan,examination-hearing-start,2023-01-02,,organisation,${currentDate},${currentDate},`,
+      "development-plan,development-plan-event,end-date,entry-date,event-date,name,notes,organisation,reference,start-date\r\n" +
+      "development-plan,public-consultation-start,,2023-01-01T00:00:00.000Z,2023-01-01,name,,organisation,1,2023-01-01T00:00:00.000Z\r\n" +
+      `development-plan,examination-hearing-start,${currentDate},2023-01-01T00:00:00.000Z,2023-01-03,name,,organisation,2,2023-01-01T00:00:00.000Z\r\n` +
+      `development-plan,examination-hearing-start,,${currentDate},2023-01-02,name,,organisation,3,${currentDate}`,
   },
   {
     name: "loaded events with changes and previously invalidated row",
@@ -256,11 +256,11 @@ const eventsTestCases: EventsTestCase[] = [
       },
     ],
     expectedCSV:
-      "reference,name,developmentPlan,developmentPlanEvent,eventDate,notes,organisation,entryDate,startDate,endDate\r\n" +
-      "1,name,development-plan,public-consultation-start,2023-01-03,,organisation,2022-12-20T00:00:00.000Z,2022-12-20T00:00:00.000Z,2023-01-01\r\n" +
-      "2,name,development-plan,public-consultation-start,2023-01-01,,organisation,2023-01-01T00:00:00.000Z,2023-01-01T00:00:00.000Z,\r\n" +
-      `3,name,development-plan,examination-hearing-start,2023-01-03,,organisation,2023-01-01T00:00:00.000Z,2023-01-01T00:00:00.000Z,${currentDate}\r\n` +
-      `4,name,development-plan,examination-hearing-start,2023-01-02,,organisation,${currentDate},${currentDate},`,
+      "development-plan,development-plan-event,end-date,entry-date,event-date,name,notes,organisation,reference,start-date\r\n" +
+      "development-plan,public-consultation-start,2023-01-01,2022-12-20T00:00:00.000Z,2023-01-03,name,,organisation,1,2022-12-20T00:00:00.000Z\r\n" +
+      "development-plan,public-consultation-start,,2023-01-01T00:00:00.000Z,2023-01-01,name,,organisation,2,2023-01-01T00:00:00.000Z\r\n" +
+      `development-plan,examination-hearing-start,${currentDate},2023-01-01T00:00:00.000Z,2023-01-03,name,,organisation,3,2023-01-01T00:00:00.000Z\r\n` +
+      `development-plan,examination-hearing-start,,${currentDate},2023-01-02,name,,organisation,4,${currentDate}`,
   },
 ];
 
@@ -290,8 +290,8 @@ const planTestCases: PlanTestCase[] = [
     },
     loadedData: null,
     expectedCSV:
-      "reference,name,description,developmentPlanType,periodStartDate,periodEndDate,developmentPlanGeography,documentationUrl,organisations,entryDate,startDate,endDate\r\n" +
-      "1,name,description,type,2023-01-01,2023-01-02,geography,url,organisations,2023-01-01T00:00:00.000Z,2023-01-01T00:00:00.000Z,",
+      "description,development-plan-geography,development-plan-type,documentation-url,end-date,entry-date,name,organisations,period-end-date,period-start-date,reference,start-date\r\n" +
+      "description,geography,type,url,,2023-01-01T00:00:00.000Z,name,organisations,2023-01-02,2023-01-01,1,2023-01-01T00:00:00.000Z",
   },
   {
     name: "loaded plan with no changes",
@@ -326,8 +326,8 @@ const planTestCases: PlanTestCase[] = [
       },
     ],
     expectedCSV:
-      "reference,name,description,developmentPlanType,periodStartDate,periodEndDate,developmentPlanGeography,documentationUrl,organisations,entryDate,startDate,endDate\r\n" +
-      "1,name,description,type,2023-01-01,2023-01-02,geography,url,organisations,2023-01-01T00:00:00.000Z,2023-01-01T00:00:00.000Z,",
+      "description,development-plan-geography,development-plan-type,documentation-url,end-date,entry-date,name,organisations,period-end-date,period-start-date,reference,start-date\r\n" +
+      "description,geography,type,url,,2023-01-01T00:00:00.000Z,name,organisations,2023-01-02,2023-01-01,1,2023-01-01T00:00:00.000Z",
   },
   {
     name: "loaded plan with changes",
@@ -362,9 +362,9 @@ const planTestCases: PlanTestCase[] = [
       },
     ],
     expectedCSV:
-      "reference,name,description,developmentPlanType,periodStartDate,periodEndDate,developmentPlanGeography,documentationUrl,organisations,entryDate,startDate,endDate\r\n" +
-      `1,name,description,type,2023-01-01,2023-01-02,geography,url,organisations,2023-01-01T00:00:00.000Z,2023-01-01T00:00:00.000Z,${currentDate}\r\n` +
-      `1,name,description,type,2023-01-01,2023-01-02,geography,url,new organisations,${currentDate},${currentDate},`,
+      "description,development-plan-geography,development-plan-type,documentation-url,end-date,entry-date,name,organisations,period-end-date,period-start-date,reference,start-date\r\n" +
+      `description,geography,type,url,${currentDate},2023-01-01T00:00:00.000Z,name,organisations,2023-01-02,2023-01-01,1,2023-01-01T00:00:00.000Z\r\n` +
+      `description,geography,type,url,,${currentDate},name,new organisations,2023-01-02,2023-01-01,1,${currentDate}`,
   },
   {
     name: "loaded plan with changes and previously invalidated row",
@@ -413,10 +413,10 @@ const planTestCases: PlanTestCase[] = [
       },
     ],
     expectedCSV:
-      "reference,name,description,developmentPlanType,periodStartDate,periodEndDate,developmentPlanGeography,documentationUrl,organisations,entryDate,startDate,endDate\r\n" +
-      "1,name,description,type,2023-01-01,2023-01-02,geography,url,old organisations,2023-01-01T00:00:00.000Z,2023-01-01T00:00:00.000Z,2023-02-03\r\n" +
-      `2,name,description,type,2023-01-01,2023-01-02,geography,url,organisations,2023-02-03T00:00:00.000Z,2023-02-03T00:00:00.000Z,${currentDate}\r\n` +
-      `2,name,description,type,2023-01-01,2023-01-02,geography,url,new organisations,${currentDate},${currentDate},`,
+      "description,development-plan-geography,development-plan-type,documentation-url,end-date,entry-date,name,organisations,period-end-date,period-start-date,reference,start-date\r\n" +
+      "description,geography,type,url,2023-02-03,2023-01-01T00:00:00.000Z,name,old organisations,2023-01-02,2023-01-01,1,2023-01-01T00:00:00.000Z\r\n" +
+      `description,geography,type,url,${currentDate},2023-02-03T00:00:00.000Z,name,organisations,2023-01-02,2023-01-01,2,2023-02-03T00:00:00.000Z\r\n` +
+      `description,geography,type,url,,${currentDate},name,new organisations,2023-01-02,2023-01-01,2,${currentDate}`,
   },
 ];
 


### PR DESCRIPTION
## Changes
- convert object keys to kebab-case when generating the CSV headers
- convert CSV headers to camelCase when creating object keys
- update assets files to have CSV headers in kebab case
- [x]  update unit tests