### PR TITLE
SOW-24: radio errors

### DIFF
--- a/lib/gds-components/radios/Radios.tsx
+++ b/lib/gds-components/radios/Radios.tsx
@@ -34,15 +34,15 @@ export const Radios = ({
             <h1 className="govuk-fieldset__heading">{label}</h1>
           </legend>
         )}
+        {error && (
+          <p className="govuk-error-message">
+            <span className="govuk-visually-hidden">Error:</span> {error}
+          </p>
+        )}
         <div
           className={cn("govuk-radios", { "govuk-radios--inline": inline })}
           data-module="govuk-radios"
         >
-          {error && (
-            <p className="govuk-error-message">
-              <span className="govuk-visually-hidden">Error:</span> {error}
-            </p>
-          )}
           {options.map(({ label, value }) => (
             <div className="govuk-radios__item" key={label}>
               <input

--- a/src/pages/status-change-event-page/status-change-event-validation.ts
+++ b/src/pages/status-change-event-page/status-change-event-validation.ts
@@ -5,7 +5,7 @@ import { eventSchema } from "../event-schema";
 const statusChangeEventSchema = eventSchema.concat(
   Joi.object({
     developmentPlanEvent: Joi.required().messages({
-      "any.required": `Status is required`,
+      "any.required": "Select the status of your Local Plan",
     }),
   })
 );

--- a/src/pages/update-timetable-status-page/update-timetable-status-validation.ts
+++ b/src/pages/update-timetable-status-page/update-timetable-status-validation.ts
@@ -3,7 +3,8 @@ import { ValidateFormParams } from "../FormPageHoc";
 
 const statusChangeEventSchema = Joi.object({
   updateStatus: Joi.boolean().messages({
-    "boolean.base": `Answer is required`,
+    "boolean.base":
+      "Select yes if you need to update the status of your Local Plan timetable",
   }),
 });
 


### PR DESCRIPTION
- Reword the error messages
   - "Answer is required" -> "Select yes if you need to update the status of your Local Plan timetable"
   - "Status is required" -> "Select the status of your Local Plan"
- Adjust the location of the error message relative to the radio options

![image](https://github.com/digital-land/local-plans-timetable/assets/29425751/8d58668c-2c2b-41b6-9e0a-f277718b5237)

![image](https://github.com/digital-land/local-plans-timetable/assets/29425751/73eb4380-f746-463c-8c65-158995136ad4)

