### PR TITLE
SOW-24: add routing page for updating dates

### DIFF
--- a/lib/gds-components/index.ts
+++ b/lib/gds-components/index.ts
@@ -10,3 +10,5 @@ export { Tag } from "./tag/Tag";
 export type { TagLabel } from "./tag/Tag";
 export { NotificationBanner } from "./notification-banner/NotificationBanner";
 export { PhaseBanner } from "./phase-banner/PhaseBanner";
+export { Radios } from "./radios/Radios";
+export type { RadioOption } from "./radios/Radios";

--- a/src/context/FormContext.tsx
+++ b/src/context/FormContext.tsx
@@ -55,6 +55,8 @@ export interface FormContextValues {
     key: keyof DevelopmentPlanTimetable,
     value: string
   ) => void;
+  shouldUpdateDates: boolean | null;
+  setShouldUpdateDates: Dispatch<SetStateAction<boolean | null>>;
 }
 
 export const FormContext = createContext<FormContextValues>({
@@ -74,6 +76,8 @@ export const FormContext = createContext<FormContextValues>({
   setStatusHasChanged: contextDefaultFunction,
   statusChangeEvent: null,
   updateStatusChangeEvent: contextDefaultFunction,
+  shouldUpdateDates: null,
+  setShouldUpdateDates: contextDefaultFunction,
 });
 
 export const FormProvider = (props: { children: ReactNode }) => {
@@ -101,6 +105,10 @@ export const FormProvider = (props: { children: ReactNode }) => {
 
   const [statusChangeEvent, setStatusChangeEvent] =
     useState<StatusChangeEvent | null>(null);
+
+  const [shouldUpdateDates, setShouldUpdateDates] = useState<boolean | null>(
+    null
+  );
 
   const updateTimetableEvent = useCallback(
     (
@@ -170,6 +178,8 @@ export const FormProvider = (props: { children: ReactNode }) => {
         setStatusHasChanged,
         statusChangeEvent,
         updateStatusChangeEvent,
+        shouldUpdateDates,
+        setShouldUpdateDates,
       }}
     >
       {props.children}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -21,6 +21,8 @@ import { validateTitle } from "./pages/title-page/validate-title-page";
 import { validatePublishLDSEvent } from "./pages/publish-LDS-page/validate-publish-LDS-page";
 import { validateStatusChangeEvent } from "./pages/status-change-event-page/status-change-event-validation";
 import { validateUpdateTimetableStatus } from "./pages/update-timetable-status-page/update-timetable-status-validation";
+import { UpdateDatesPage } from "./pages/update-dates-page/UpdateDatesPage";
+import { validateUpdateDates } from "./pages/update-dates-page/update-dates-validation";
 import { validateLPA } from "./pages/LPA-page/lpa-validation";
 import { stages } from "./pages/stages";
 import { Page } from "./routes/Page";
@@ -101,6 +103,10 @@ const router = createBrowserRouter(
             {},
             validateStatusChangeEvent
           ),
+        },
+        {
+          path: PageRoute.UpdateDates,
+          element: FormPageHoC(UpdateDatesPage, {}, validateUpdateDates),
         },
         ...stages.map(({ key, ...otherProps }) => ({
           path: key,

--- a/src/pages/FormPageHoc.tsx
+++ b/src/pages/FormPageHoc.tsx
@@ -18,6 +18,7 @@ export type ValidateFormParams<P> = {
   timetableEvents: DevelopmentPlanTimetable[];
   statusChangeEvent: StatusChangeEvent | null;
   statusHasChanged: boolean | null;
+  shouldUpdateDates: boolean | null;
   loadedDevelopmentPlan: DevelopmentPlan[] | null;
   loadedTimetableEvents: DevelopmentPlanTimetable[] | null;
   formProps: P;
@@ -36,6 +37,7 @@ export const FormPageHoC = <P extends Record<string, unknown>>(
       timetableEvents,
       statusChangeEvent,
       statusHasChanged,
+      shouldUpdateDates,
       userFlow,
       loadedDevelopmentPlan,
       loadedTimetableEvents,
@@ -43,7 +45,8 @@ export const FormPageHoC = <P extends Record<string, unknown>>(
 
     const { previousPage, navigateNext } = useSequence(
       userFlow,
-      statusHasChanged ?? true
+      statusHasChanged ?? true,
+      shouldUpdateDates ?? true
     );
     const [errors, setErrors] = useState<ValidationErrorItem[]>();
 
@@ -54,6 +57,7 @@ export const FormPageHoC = <P extends Record<string, unknown>>(
         timetableEvents,
         statusChangeEvent,
         statusHasChanged,
+        shouldUpdateDates,
         formProps,
         loadedDevelopmentPlan,
         loadedTimetableEvents,

--- a/src/pages/status-change-event-page/StatusChangeEventPage.tsx
+++ b/src/pages/status-change-event-page/StatusChangeEventPage.tsx
@@ -1,6 +1,5 @@
 import { StatusChangeEventKey, TimetableEventKey } from "@lib/constants";
-import { DateInput, TextArea } from "@lib/gds-components";
-import { RadioOption, Radios } from "@lib/gds-components/radios/Radios";
+import { DateInput, RadioOption, Radios, TextArea } from "@lib/gds-components";
 import { ValidationErrorItem } from "joi";
 import { useFormContext } from "../../context/use-form-context";
 

--- a/src/pages/update-dates-page/UpdateDatesPage.tsx
+++ b/src/pages/update-dates-page/UpdateDatesPage.tsx
@@ -1,0 +1,35 @@
+import { ValidationErrorItem } from "joi";
+
+import { Radios } from "@lib/gds-components";
+import { useFormContext } from "../../context/use-form-context";
+
+interface UpdateDatesPageProps {
+  errors: ValidationErrorItem[] | undefined;
+}
+
+export const UpdateDatesPage = ({
+  errors,
+}: UpdateDatesPageProps): JSX.Element => {
+  const { shouldUpdateDates, setShouldUpdateDates } = useFormContext();
+
+  const radioValue = shouldUpdateDates?.toString();
+
+  return (
+    <>
+      <h1 className="govuk-heading-l govuk-!-margin-top-6 govuk-!-width-two-thirds govuk-!-margin-bottom-7">
+        Do you need to update the dates of your Local Plan timetable?
+      </h1>
+      <Radios
+        onChange={(value) => setShouldUpdateDates(value === "true")}
+        inline
+        options={[
+          { label: "Yes", value: "true" },
+          { label: "No", value: "false" },
+        ]}
+        selectedOption={radioValue}
+        error={errors?.[0].message}
+        id="updateDates"
+      />
+    </>
+  );
+};

--- a/src/pages/update-dates-page/update-dates-validation.ts
+++ b/src/pages/update-dates-page/update-dates-validation.ts
@@ -1,0 +1,25 @@
+import Joi, { ValidationErrorItem } from "joi";
+import { ValidateFormParams } from "../FormPageHoc";
+
+const updateDatesEventSchema = Joi.object({
+  updateDates: Joi.boolean().messages({
+    "boolean.base":
+      "Select yes if you need to update the dates of your Local Plan timetable",
+  }),
+});
+
+export const validateUpdateDates = ({
+  shouldUpdateDates,
+}: ValidateFormParams<Record<string, never>>) => {
+  const errors: ValidationErrorItem[] = [];
+
+  const validationResult = updateDatesEventSchema.validate({
+    updateDates: shouldUpdateDates,
+  });
+
+  if (validationResult.error) {
+    errors.push(...validationResult.error.details);
+  }
+
+  return errors;
+};

--- a/src/pages/update-timetable-status-page/UpdateTimetableStatusPage.tsx
+++ b/src/pages/update-timetable-status-page/UpdateTimetableStatusPage.tsx
@@ -1,4 +1,4 @@
-import { Radios } from "@lib/gds-components/radios/Radios";
+import { Radios } from "@lib/gds-components";
 import { ValidationErrorItem } from "joi";
 import { useFormContext } from "../../context/use-form-context";
 

--- a/src/pages/use-sequence.ts
+++ b/src/pages/use-sequence.ts
@@ -8,7 +8,8 @@ const routesOnCondition = (condition: boolean, ...routes: PageRoute[]) =>
 
 const getSequence = (
   userJourney: Journey | null,
-  timetableStatusHasChanged?: boolean
+  timetableStatusHasChanged: boolean,
+  shouldUpdateDates: boolean
 ) => {
   if (!userJourney) {
     return [];
@@ -30,22 +31,28 @@ const getSequence = (
       userJourney === Journey.Update && !!timetableStatusHasChanged,
       PageRoute.StatusChangeEvent
     ),
-    PageRoute.PublishLocalDevelopmentScheme,
-    ...stages.map((stage) => stage.key),
+    ...routesOnCondition(userJourney === Journey.Update, PageRoute.UpdateDates),
+    ...routesOnCondition(
+      userJourney === Journey.Create || shouldUpdateDates,
+      PageRoute.PublishLocalDevelopmentScheme,
+      ...stages.map((stage) => stage.key)
+    ),
     PageRoute.Export,
   ];
 };
 
 export const useSequence = (
   userJourney: Journey | null,
-  timetableStatusHasChanged?: boolean
+  timetableStatusHasChanged: boolean,
+  shouldUpdateDates: boolean
 ) => {
   const navigate = useNavigate();
   const { pathname } = useLocation() as { pathname: PageRoute };
 
   const sequence = useMemo(
-    () => getSequence(userJourney, timetableStatusHasChanged),
-    [userJourney, timetableStatusHasChanged]
+    () =>
+      getSequence(userJourney, timetableStatusHasChanged, shouldUpdateDates),
+    [userJourney, timetableStatusHasChanged, shouldUpdateDates]
   );
 
   const currentPageIndex = sequence.indexOf(pathname);

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -17,7 +17,8 @@ export enum PageRoute {
   Export = "/export-your-timetable",
   UpdateTimetableStatus = "/update-your-timetable-status",
   StatusChangeEvent = "/about-the-status-change",
-  VisualisationExample = "/what-a-local-plan-timetable-looks-like"
+  UpdateDates = "/update-your-timetable-dates",
+  VisualisationExample = "/what-a-local-plan-timetable-looks-like",
 }
 
 export enum Journey {


### PR DESCRIPTION
Add a new page in the edit journey to ask if a user wants to update their dates:
- If yes, continue as before
- If no, skip straight to the export page

Also added basic validation in line with the equivalent page for timetable status.