### PR TITLE
SOW-24: add text to copy button

### DIFF
--- a/lib/gds-components/button/Button.tsx
+++ b/lib/gds-components/button/Button.tsx
@@ -2,14 +2,17 @@
  * GDS component: https://design-system.service.gov.uk/components/button/
  */
 
+import cn from "classnames";
+
 interface ButtonProps {
   children?: React.ReactNode;
   type?: "submit" | "button" | "reset";
   onClick?: () => void;
+  className?: string
 }
 
-export const Button = ({ children, type = "button", onClick }: ButtonProps) => (
-  <button type={type} className="govuk-button" onClick={onClick}>
+export const Button = ({ children, type = "button", onClick, className }: ButtonProps) => (
+  <button type={type} className={cn("govuk-button", className)} onClick={onClick}>
     {children}
   </button>
 );

--- a/lib/snippet/Snippet.tsx
+++ b/lib/snippet/Snippet.tsx
@@ -1,4 +1,8 @@
-import { CopyBlock } from "react-code-blocks";
+import { useState } from "react";
+
+import { CodeBlock } from "react-code-blocks";
+
+import { Button } from "../gds-components/button/Button";
 
 import styles from "./snippet.module.css";
 
@@ -8,18 +12,32 @@ type SnippetProps = {
   showLineNumbers?: boolean;
 };
 
+const defaultCopyButtonText = "Copy code";
+
 export const Snippet = ({
   code,
   language = "html",
   showLineNumbers = false,
 }: SnippetProps) => {
+  const [buttonText, setButtonText] = useState<string>(defaultCopyButtonText);
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(code).then(() => {
+      setButtonText("Code copied");
+      setTimeout(() => setButtonText(defaultCopyButtonText), 5000);
+    });
+  };
+
   return (
     <div className={styles.snippet}>
-      <CopyBlock
+      <Button onClick={handleCopy} className={styles.copyButton}>
+        {buttonText}
+      </Button>
+      <CodeBlock
         language={language}
         text={code}
         showLineNumbers={showLineNumbers}
-        codeBlock
+        codeContainerStyle={{ paddingTop: 35 }}
       />
     </div>
   );

--- a/lib/snippet/snippet.module.css
+++ b/lib/snippet/snippet.module.css
@@ -2,4 +2,30 @@
   font-family: monospace;
   font-size: 20px;
   margin-bottom: 20px;
+  position: relative;
+}
+
+.copyButton:focus {
+  background-color: #fd0;
+  color: black;
+}
+
+.copyButton,
+.copyButton:hover {
+  background-color: #fff;
+  color: #00823b;
+  position: absolute;
+  right: 10px;
+  top: 10px;
+  width: 120px;
+  padding: 3px 10px;
+  line-height: 1.25;
+  border: 1px solid #00823b;
+  font-size: 1rem;
+  box-shadow: 0 2px 0 0 #00823b;
+}
+
+.copyButton:focus:hover {
+  border: 2px solid #fd0;
+  box-shadow: none;
 }

--- a/lib/snippet/snippet.module.css
+++ b/lib/snippet/snippet.module.css
@@ -28,4 +28,6 @@
 .copyButton:focus:hover {
   border: 2px solid #fd0;
   box-shadow: none;
+  padding: 2px 10px;
+  outline: 2px solid rgba(0, 0, 0, 0);
 }

--- a/lib/snippet/snippet.module.css
+++ b/lib/snippet/snippet.module.css
@@ -5,13 +5,13 @@
   position: relative;
 }
 
-.copyButton:focus {
+.copy-button:focus {
   background-color: #fd0;
   color: black;
 }
 
-.copyButton,
-.copyButton:hover {
+.copy-button,
+.copy-button:hover {
   background-color: #fff;
   color: #00823b;
   position: absolute;
@@ -25,7 +25,7 @@
   box-shadow: 0 2px 0 0 #00823b;
 }
 
-.copyButton:focus:hover {
+.copy-button:focus:hover {
   border: 2px solid #fd0;
   box-shadow: none;
   padding: 2px 10px;


### PR DESCRIPTION
## Changes
- use CodeBlock instead of CopyBlock (only difference between the 2 components is the copy button)
- add custom copy button
- add custom style for copy button 