### PR TITLE
SOW-24: add a type check step to PR workflow

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -1,7 +1,0 @@
-name: Lint and Unit Test
-
-on: [pull_request]
-
-jobs:
-  lint-and-test:
-    uses: ./.github/workflows/shared-steps.yml

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,35 @@
+name: Lint and Unit Test
+
+on: [pull_request]
+
+jobs:
+  lint-and-test:
+    uses: ./.github/workflows/shared-steps.yml
+  form-type-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+          cache: "npm"
+
+      - run: npm ci
+
+      - name: Check form application types
+        run: npm run ts-compile:form
+  cdn-type-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+          cache: "npm"
+
+      - run: npm ci
+
+      - name: Check CDN component types
+        run: npm run ts-compile:cdn

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Shows a preview of the build locally.
 
 Copies the GOV.UK Frontend font assets to the `public` folder.
 
+### `npm run ts-compile:form`
+
+Compiles the TypeScript for the form application.
+
 ### `npm run build`
 
 Builds the App for production to the `dist` folder.
@@ -47,6 +51,10 @@ Starts Storybook. Open [http://localhost:6006](http://localhost:6006) to view it
 ### `npm run build:storybook`
 
 Builds Storybook to the `storybook-static` folder.
+
+### `npm run ts-compile:cdn`
+
+Compiles the TypeScript for the CDN component.
 
 ### `npm run build:cdn`
 

--- a/package.json
+++ b/package.json
@@ -11,13 +11,15 @@
   "scripts": {
     "prebuild": "node ./scripts/wrapper-pre-build.cjs",
     "dev": "npm run prebuild && vite --open",
-    "build": "tsc && vite build",
+    "ts-compile:form": "tsc",
+    "build": "npm run ts-compile:form && vite build",
     "postbuild": "node ./scripts/wrapper-post-build.cjs",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "storybook": "storybook dev -p 6006",
     "build:storybook": "storybook build",
-    "build:cdn": "tsc --p ./tsconfig-cdn-build.json && vite --config cdn-vite.config.ts build",
+    "ts-compile:cdn": "tsc --p ./tsconfig-cdn-build.json",
+    "build:cdn": "npm run ts-compile:cdn && vite --config cdn-vite.config.ts build",
     "postbuild:cdn": "node ./scripts/cdn-post-build.cjs",
     "test": "jest",
     "test:watch": "jest --watch"


### PR DESCRIPTION
Add type checks to the PR workflow for both build steps so we know if they'll fail before we merge