### PR TITLE
SOW-24: re-add back button to export page

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -70,51 +70,83 @@ const router = createBrowserRouter(
         },
         {
           path: PageRoute.UploadTimetable,
-          element: FormPageHoC(UploadTimetablePage, {}, validateUpload),
+          element: FormPageHoC({
+            FormComponent: UploadTimetablePage,
+            formProps: {},
+            validatePage: validateUpload,
+          }),
         },
         {
           path: PageRoute.LPA,
-          element: FormPageHoC(LPAPage, {}, validateLPA),
+          element: FormPageHoC({
+            FormComponent: LPAPage,
+            formProps: {},
+            validatePage: validateLPA,
+          }),
         },
         {
           path: PageRoute.Title,
-          element: FormPageHoC(TitlePage, {}, validateTitle),
+          element: FormPageHoC({
+            FormComponent: TitlePage,
+            formProps: {},
+            validatePage: validateTitle,
+          }),
         },
         {
           path: PageRoute.Description,
-          element: FormPageHoC(DescriptionPage, {}, validateDescription),
+          element: FormPageHoC({
+            FormComponent: DescriptionPage,
+            formProps: {},
+            validatePage: validateDescription,
+          }),
         },
         {
           path: PageRoute.PublishLocalDevelopmentScheme,
-          element: FormPageHoC(PublishLDSPage, {}, validatePublishLDSEvent),
+          element: FormPageHoC({
+            FormComponent: PublishLDSPage,
+            formProps: {},
+            validatePage: validatePublishLDSEvent,
+          }),
         },
         {
           path: PageRoute.UpdateTimetableStatus,
-          element: FormPageHoC(
-            UpdateTimetableStatusPage,
-            {},
-            validateUpdateTimetableStatus
-          ),
+          element: FormPageHoC({
+            FormComponent: UpdateTimetableStatusPage,
+            formProps: {},
+            validatePage: validateUpdateTimetableStatus,
+          }),
         },
         {
           path: PageRoute.StatusChangeEvent,
-          element: FormPageHoC(
-            StatusChangeEventPage,
-            {},
-            validateStatusChangeEvent
-          ),
+          element: FormPageHoC({
+            FormComponent: StatusChangeEventPage,
+            formProps: {},
+            validatePage: validateStatusChangeEvent,
+          }),
         },
         {
           path: PageRoute.UpdateDates,
-          element: FormPageHoC(UpdateDatesPage, {}, validateUpdateDates),
+          element: FormPageHoC({
+            FormComponent: UpdateDatesPage,
+            formProps: {},
+            validatePage: validateUpdateDates,
+          }),
         },
         ...stages.map(({ key, ...otherProps }) => ({
           path: key,
-          element: FormPageHoC(StagePage, otherProps, validateTimetableStage),
+          element: FormPageHoC({
+            FormComponent: StagePage,
+            formProps: otherProps,
+            validatePage: validateTimetableStage,
+          }),
         })),
         {
           path: PageRoute.Export,
-          element: <ExportPage/>,
+          element: FormPageHoC({
+            FormComponent: ExportPage,
+            formProps: {},
+            twoThirdsWidth: false,
+          }),
         },
         {
           path: PageRoute.VisualisationExample,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,7 +13,7 @@ import {
   CreateTimetablePage,
   ExportPage,
 } from "./pages";
-import { FormPageHoC } from "./pages/FormPageHoc";
+import { FormPageHoc } from "./pages/FormPageHoc";
 import { validateDescription } from "./pages/description-page/description-validation";
 import { validateTimetableStage } from "./pages/stage-page/validate-stage-page";
 import { validateUpload } from "./pages/upload-timetable-page/validate-upload-timetable-page";
@@ -70,7 +70,7 @@ const router = createBrowserRouter(
         },
         {
           path: PageRoute.UploadTimetable,
-          element: FormPageHoC({
+          element: FormPageHoc({
             FormComponent: UploadTimetablePage,
             formProps: {},
             validatePage: validateUpload,
@@ -78,7 +78,7 @@ const router = createBrowserRouter(
         },
         {
           path: PageRoute.LPA,
-          element: FormPageHoC({
+          element: FormPageHoc({
             FormComponent: LPAPage,
             formProps: {},
             validatePage: validateLPA,
@@ -86,7 +86,7 @@ const router = createBrowserRouter(
         },
         {
           path: PageRoute.Title,
-          element: FormPageHoC({
+          element: FormPageHoc({
             FormComponent: TitlePage,
             formProps: {},
             validatePage: validateTitle,
@@ -94,7 +94,7 @@ const router = createBrowserRouter(
         },
         {
           path: PageRoute.Description,
-          element: FormPageHoC({
+          element: FormPageHoc({
             FormComponent: DescriptionPage,
             formProps: {},
             validatePage: validateDescription,
@@ -102,7 +102,7 @@ const router = createBrowserRouter(
         },
         {
           path: PageRoute.PublishLocalDevelopmentScheme,
-          element: FormPageHoC({
+          element: FormPageHoc({
             FormComponent: PublishLDSPage,
             formProps: {},
             validatePage: validatePublishLDSEvent,
@@ -110,7 +110,7 @@ const router = createBrowserRouter(
         },
         {
           path: PageRoute.UpdateTimetableStatus,
-          element: FormPageHoC({
+          element: FormPageHoc({
             FormComponent: UpdateTimetableStatusPage,
             formProps: {},
             validatePage: validateUpdateTimetableStatus,
@@ -118,7 +118,7 @@ const router = createBrowserRouter(
         },
         {
           path: PageRoute.StatusChangeEvent,
-          element: FormPageHoC({
+          element: FormPageHoc({
             FormComponent: StatusChangeEventPage,
             formProps: {},
             validatePage: validateStatusChangeEvent,
@@ -126,7 +126,7 @@ const router = createBrowserRouter(
         },
         {
           path: PageRoute.UpdateDates,
-          element: FormPageHoC({
+          element: FormPageHoc({
             FormComponent: UpdateDatesPage,
             formProps: {},
             validatePage: validateUpdateDates,
@@ -134,7 +134,7 @@ const router = createBrowserRouter(
         },
         ...stages.map(({ key, ...otherProps }) => ({
           path: key,
-          element: FormPageHoC({
+          element: FormPageHoc({
             FormComponent: StagePage,
             formProps: otherProps,
             validatePage: validateTimetableStage,
@@ -142,7 +142,7 @@ const router = createBrowserRouter(
         })),
         {
           path: PageRoute.Export,
-          element: FormPageHoC({
+          element: FormPageHoc({
             FormComponent: ExportPage,
             formProps: {},
             twoThirdsWidth: false,

--- a/src/pages/FormPageHoc.tsx
+++ b/src/pages/FormPageHoc.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
-
 import { ValidationErrorItem } from "joi";
+import cn from "classnames";
 
 import { Button, ErrorSummary } from "@lib/gds-components";
 import {
@@ -24,13 +24,21 @@ export type ValidateFormParams<P> = {
   formProps: P;
 };
 
-export const FormPageHoC = <P extends Record<string, unknown>>(
+interface FormPageHoCProps<P extends Record<string, unknown>> {
   FormComponent: (
     props: P & { errors: ValidationErrorItem[] | undefined }
-  ) => JSX.Element,
-  formProps: P,
-  validatePage?: (params: ValidateFormParams<P>) => ValidationErrorItem[]
-) => {
+  ) => JSX.Element;
+  formProps: P;
+  validatePage?: (params: ValidateFormParams<P>) => ValidationErrorItem[];
+  twoThirdsWidth?: boolean;
+}
+
+export const FormPageHoC = <P extends Record<string, unknown>>({
+  FormComponent,
+  formProps,
+  validatePage,
+  twoThirdsWidth = true,
+}: FormPageHoCProps<P>) => {
   const InnerComponent = () => {
     const {
       developmentPlan,
@@ -83,9 +91,12 @@ export const FormPageHoC = <P extends Record<string, unknown>>(
         <Link to={previousPage} className="govuk-back-link">
           Back
         </Link>
-        <form onSubmit={handleClick} className="govuk-!-width-two-thirds">
+        <form
+          onSubmit={handleClick}
+          className={cn({ "govuk-!-width-two-thirds": twoThirdsWidth })}
+        >
           <ErrorSummary errors={errors} />
-          <FormComponent {...formProps} errors={errors}/>
+          <FormComponent {...formProps} errors={errors} />
           {navigateNext && <Button type="submit">Continue</Button>}
         </form>
       </>

--- a/src/pages/FormPageHoc.tsx
+++ b/src/pages/FormPageHoc.tsx
@@ -24,7 +24,7 @@ export type ValidateFormParams<P> = {
   formProps: P;
 };
 
-interface FormPageHoCProps<P extends Record<string, unknown>> {
+interface FormPageHocProps<P extends Record<string, unknown>> {
   FormComponent: (
     props: P & { errors: ValidationErrorItem[] | undefined }
   ) => JSX.Element;
@@ -33,12 +33,12 @@ interface FormPageHoCProps<P extends Record<string, unknown>> {
   twoThirdsWidth?: boolean;
 }
 
-export const FormPageHoC = <P extends Record<string, unknown>>({
+export const FormPageHoc = <P extends Record<string, unknown>>({
   FormComponent,
   formProps,
   validatePage,
   twoThirdsWidth = true,
-}: FormPageHoCProps<P>) => {
+}: FormPageHocProps<P>) => {
   const InnerComponent = () => {
     const {
       developmentPlan,


### PR DESCRIPTION
Re-add the back button to the export page by going back to using `FormPageHoC`. The `govuk-!-width-two-thirds` class on the form is now added using a prop, so we don't add it to the entire export page (the visualisation needs to be full width).

I spent some time trying to make `formProps` only required when form component actually _has_ props but couldn't find an obvious nice way to do it and didn't want to spend any more time on it.